### PR TITLE
Mccalluc/ignore dot files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Mirror Globus directory to local cache.
 - Fix `--type_metadata` so it still works without a submission directory.
 - Add `--optional_fields` to temporarily ignore the given fields.
+- Ignore dot-files. No command-line option to enable stricter validation, for now.
 ### Changed
 - Make the ATACseq validation more flexible.
 - Less confusing representation of enums in docs.

--- a/src/ingest_validation_tools/directory_validator/validator.py
+++ b/src/ingest_validation_tools/directory_validator/validator.py
@@ -39,6 +39,8 @@ def _dir_to_list(path, ignore_dot_files=True):
     items_to_return = []
     with os.scandir(path) as scan:
         for entry in sorted(scan, key=lambda entry: entry.name):
+            if ignore_dot_files and entry.name[0] == '.':
+                continue
             is_dir = entry.is_dir()
             item = {
                 'type': 'directory' if is_dir else 'file',

--- a/src/ingest_validation_tools/directory_validator/validator.py
+++ b/src/ingest_validation_tools/directory_validator/validator.py
@@ -21,7 +21,7 @@ def validate(path, schema_dict):
         raise DirectoryValidationErrors(errors)
 
 
-def _dir_to_list(path):
+def _dir_to_list(path, ignore_dot_files=True):
     '''
     Walk the directory at `path`, and return a dict like that from `tree -J`:
 


### PR DESCRIPTION
Fix #173.

@cebriggs7135 : This will prevent stray invisible files whose names begin with `.` from causing an invalid submission. Mostly commonly, this is `.DS_Store` on Macs. Perhaps is should be more strict, and only ignore that particular name? For now, when we're trying to get _anything_ to validate, I think this is ok. Does it have your approval?

@john-conroy : Code review. Thanks!
