### PR TITLE
Remove resolution_z_value and resolution_z_unit from AF microscopy

### DIFF
--- a/src/ingest_validation_tools/table-schemas/af.yaml
+++ b/src/ingest_validation_tools/table-schemas/af.yaml
@@ -24,12 +24,6 @@ fields:
     name: resolution_y_unit
     description: TODO
   -
-    name: resolution_z_value
-    description: TODO
-  -
-    name: resolution_z_unit
-    description: TODO
-  -
     name: number_of_channels
     description: TODO
   -


### PR DESCRIPTION
… microscopy

several imaging assays don't capture z-plane images.