### PR TITLE
Mccalluc/polysaccharides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Additional scrnaseq types and columns.
 - Add a number of Assay types for Vanderbilt.
+- Add polysaccharides as analyte_class.
 ### Changed
 - Remove parenthesis from assay type.
 - Assume Latin-1 encoding for TSVs rather than UTF-8.

--- a/docs/af/README.md
+++ b/docs/af/README.md
@@ -129,7 +129,7 @@ Analytes are the target molecules being measured with the assay.
 
 | constraint | value |
 | --- | --- |
-| enum | `DNA`, `RNA`, `protein`, `lipids`, or `metabolites` |
+| enum | `DNA`, `RNA`, `protein`, `lipids`, `metabolites`, or `polysaccharides` |
 | required | `True` |
 
 ### `is_targeted`

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -142,7 +142,7 @@ Analytes are the target molecules being measured with the assay.
 
 | constraint | value |
 | --- | --- |
-| enum | `DNA`, `RNA`, `protein`, `lipids`, or `metabolites` |
+| enum | `DNA`, `RNA`, `protein`, `lipids`, `metabolites`, or `polysaccharides` |
 | required | `True` |
 
 ### `is_targeted`

--- a/docs/lcms/README.md
+++ b/docs/lcms/README.md
@@ -145,7 +145,7 @@ Analytes are the target molecules being measured with the assay.
 
 | constraint | value |
 | --- | --- |
-| enum | `DNA`, `RNA`, `protein`, `lipids`, or `metabolites` |
+| enum | `DNA`, `RNA`, `protein`, `lipids`, `metabolites`, or `polysaccharides` |
 | required | `True` |
 
 ### `is_targeted`

--- a/docs/maldiims/README.md
+++ b/docs/maldiims/README.md
@@ -136,7 +136,7 @@ Analytes are the target molecules being measured with the assay.
 
 | constraint | value |
 | --- | --- |
-| enum | `DNA`, `RNA`, `protein`, `lipids`, or `metabolites` |
+| enum | `DNA`, `RNA`, `protein`, `lipids`, `metabolites`, or `polysaccharides` |
 | required | `True` |
 
 ### `is_targeted`

--- a/docs/mixif/README.md
+++ b/docs/mixif/README.md
@@ -132,7 +132,7 @@ Analytes are the target molecules being measured with the assay.
 
 | constraint | value |
 | --- | --- |
-| enum | `DNA`, `RNA`, `protein`, `lipids`, or `metabolites` |
+| enum | `DNA`, `RNA`, `protein`, `lipids`, `metabolites`, or `polysaccharides` |
 | required | `True` |
 
 ### `is_targeted`

--- a/docs/seqfish/README.md
+++ b/docs/seqfish/README.md
@@ -141,7 +141,7 @@ Analytes are the target molecules being measured with the assay.
 
 | constraint | value |
 | --- | --- |
-| enum | `DNA`, `RNA`, `protein`, `lipids`, or `metabolites` |
+| enum | `DNA`, `RNA`, `protein`, `lipids`, `metabolites`, or `polysaccharides` |
 | required | `True` |
 
 ### `is_targeted`

--- a/docs/stained/README.md
+++ b/docs/stained/README.md
@@ -130,8 +130,7 @@ Analytes are the target molecules being measured with the assay.
 
 | constraint | value |
 | --- | --- |
-| enum | `DNA`, `RNA`, `protein`, `lipids`, or `metabolites` |
-| required | `True` |
+| required | `False` |
 
 ### `is_targeted`
 Specifies whether or not a specific molecule(s) is/are targeted for detection/measurement by the assay. The CODEX analyte is protein.

--- a/examples/bad-tsv-formats/README.md
+++ b/examples/bad-tsv-formats/README.md
@@ -13,7 +13,8 @@ Metadata TSV Errors:
     - The value "pi_emailATexample.com" in row 2 and column 8 ("H") is not type "string"
       and format "email"
     - 'The value "analyte_class" in row 2 and column 11 ("K") does not conform to
-      the given enumeration: "[''DNA'', ''RNA'', ''protein'', ''lipids'', ''metabolites'']"'
+      the given enumeration: "[''DNA'', ''RNA'', ''protein'', ''lipids'', ''metabolites'',
+      ''polysaccharides'']"'
     - The value "is_targeted" in row 2 and column 12 ("L") is not type "boolean" and
       format "default"
     - 'The value "acquisition_instrument_vendor" in row 2 and column 13 ("M") does

--- a/src/ingest_validation_tools/table-schemas/level-1.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-1.yaml
@@ -77,6 +77,7 @@ fields:
         - protein
         - lipids
         - metabolites
+        - polysaccharides
   -
     name: is_targeted
     description: Specifies whether or not a specific molecule(s) is/are targeted for detection/measurement by the assay. The CODEX analyte is protein.

--- a/src/ingest_validation_tools/table-schemas/level-2/stained.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-2/stained.yaml
@@ -1,6 +1,10 @@
 doc_url: TODO
 fields:
   # Overrides of Level 1 fields:
+  -
+    name: analyte_class
+    constraints:
+      required: False
 
   # TODO
 


### PR DESCRIPTION
Fix  #205.

@cebriggs7135 : I strongly believe we should not use strings like "NA": If a particular assay does not have a value, we should leave it blank. We can accommodate this by overriding the level-1 schema on a per-type basis. If there are other assay types besides `stained` where `analyte_class` is not used, let me know, or make the PRs yourself, whichever you prefer.