### PR TITLE
modify atacseq constraints for cell_barcode_read/offset/size

### DIFF
--- a/src/ingest_validation_tools/table-schemas/level-2/atacseq.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-2/atacseq.yaml
@@ -109,17 +109,17 @@ fields:
     name: cell_barcode_read
     description: Which read file contains the cell barcode.
     constraints:
-      pattern: '[A-Z]\d+(,[A-Z]\d+)*'
+      required: True
   -
     name: cell_barcode_offset
     description: Positions in the read at which the cell barcodes start. Cell barcodes are, for example, 3 x 8 bp sequences that are spaced by constant sequences (the offsets). First barcode at position 0, then 38, then 76. (Does not apply to SNARE-seq and BulkATAC.)
     constraints:
-      pattern: '\d+(,\d+)*'
+      required: True
   -
     name: cell_barcode_size
     description: Length of the cell barcode in base pairs. Cell barcodes are, for example, 3 x 8 bp sequences that are spaced by constant sequences, the offsets. (Does not apply to SNARE-seq and BulkATAC.)
     constraints:
-      pattern: '\d+(,\d+)*'
+      required: True
   -
     name: library_pcr_cycles
     description: Number of PCR cycles to enrich for accessible chromatin fragments.


### PR DESCRIPTION
These should be required: True but with no required pattern, just like scrnaseq.