### PR TITLE
LC-MS: more enum for lc_flow_rate_unit & lc_length_unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Free-form cell_barcode_read.
 - Add bulkrnaseq, bulkatacseq, and wgs fields.
 - mass/charge is unitless in MS: Remove field.
+- lcms units
 ### Removed
 - avg_insert_size from bulkatacseq.
 

--- a/docs/lcms/README.md
+++ b/docs/lcms/README.md
@@ -279,7 +279,7 @@ units for LC column length (typically cm)
 
 | constraint | value |
 | --- | --- |
-| enum | `cm` |
+| enum | `mm` or `cm` |
 | required | `True` |
 
 ### `lc_temp_value`
@@ -328,7 +328,7 @@ Units of flow rate. Leave blank if not applicable.
 | constraint | value |
 | --- | --- |
 | required | `False` |
-| enum | `nL/min` |
+| enum | `nL/min` or `ml/min` |
 
 ### `lc_gradient`
 LC gradient

--- a/docs/lcms/unified.yaml
+++ b/docs/lcms/unified.yaml
@@ -176,6 +176,7 @@ fields:
   type: number
 - constraints:
     enum:
+    - mm
     - cm
     required: true
   description: units for LC column length (typically cm)
@@ -210,6 +211,7 @@ fields:
 - constraints:
     enum:
     - nL/min
+    - ml/min
     required: false
   description: Units of flow rate.
   name: lc_flow_rate_unit

--- a/src/ingest_validation_tools/table-schemas/level-2/lcms.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-2/lcms.yaml
@@ -62,7 +62,8 @@ fields:
     description: units for LC column length (typically cm)
     constraints:
       enum:
-        - mm, cm
+        - mm
+        - cm
   -
     name: lc_temp_value
     description: LC temperature
@@ -92,7 +93,8 @@ fields:
     constraints:
       required: False
       enum:
-        - nL/min , ml/min
+        - nL/min
+        - ml/min
   -
     name: lc_gradient
     description: LC gradient

--- a/src/ingest_validation_tools/table-schemas/level-2/lcms.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-2/lcms.yaml
@@ -62,7 +62,7 @@ fields:
     description: units for LC column length (typically cm)
     constraints:
       enum:
-        - cm
+        - mm, cm
   -
     name: lc_temp_value
     description: LC temperature
@@ -92,7 +92,7 @@ fields:
     constraints:
       required: False
       enum:
-        - nL/min
+        - nL/min , ml/min
   -
     name: lc_gradient
     description: LC gradient

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,10 @@ start() { [[ -z $CI ]] || echo travis_fold':'start:$1; echo $green$1$reset; }
 end() { [[ -z $CI ]] || echo travis_fold':'end:$1; }
 die() { set +v; echo "$red$*$reset" 1>&2 ; exit 1; }
 
+start generate
+./test-generate.sh
+end generate
+
 start flake8
 flake8 || die 'Try: autopep8 --in-place --aggressive -r .'
 end flake8
@@ -23,10 +27,6 @@ end schemas-exist
 start examples
 ./test-examples.sh
 end examples
-
-start generate
-./test-generate.sh
-end generate
 
 start cli-docs
 ./test-cli-docs.sh


### PR DESCRIPTION

![Screen Shot 2020-05-20 at 4 29 26 PM](https://user-images.githubusercontent.com/8284878/82494192-33626300-9ab7-11ea-8dce-8ef3b10a5aa7.png)
This PR was in DONE but it's not:

lc_flow_rate_unit
enum:
- nL/min, ml/min

lc_length_unit
enum:
-mm, cm