### PR TITLE
TO DO for bulkATACseq metadata

### DIFF
--- a/docs/bulkatacseq/README.md
+++ b/docs/bulkatacseq/README.md
@@ -309,10 +309,11 @@ Percent PhiX loaded to the run
 | maximum | `100` |
 
 ### `sequencing_read_format`
-Number of sequencing cycles in Read1, i7 index, i5 index, and Read2 - TODO https://github.com/hubmapconsortium/ingest-validation-tools/issues/303
+Slash-delimited list of the number of sequencing cycles for, for example, Read1, i7 index, i5 index, and Read2.
 
 | constraint | value |
 | --- | --- |
+| pattern (regular expression) | `\d+(/\d+)+` |
 | required | `True` |
 
 ### `sequencing_read_percent_q30`

--- a/docs/bulkatacseq/unified.yaml
+++ b/docs/bulkatacseq/unified.yaml
@@ -187,9 +187,10 @@ fields:
   name: sequencing_phix_percent
   type: number
 - constraints:
+    pattern: \d+(/\d+)+
     required: true
-  description: Number of sequencing cycles in Read1, i7 index, i5 index, and Read2
-    - TODO https://github.com/hubmapconsortium/ingest-validation-tools/issues/303
+  description: Slash-delimited list of the number of sequencing cycles for, for example,
+    Read1, i7 index, i5 index, and Read2.
   name: sequencing_read_format
 - constraints:
     maximum: 100

--- a/src/ingest_validation_tools/table-schemas/level-2/bulkatacseq.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-2/bulkatacseq.yaml
@@ -88,7 +88,9 @@ fields:
 - name: sequencing_phix_percent
   description: Percent PhiX loaded to the run
 - name: sequencing_read_format
-  description: 'Number of sequencing cycles in Read1, i7 index, i5 index, and Read2 - TODO https://github.com/hubmapconsortium/ingest-validation-tools/issues/303'
+  description: Slash-delimited list of the number of sequencing cycles for, for example, Read1, i7 index, i5 index, and Read2.
+  constraints:
+    pattern: '\d+(/\d+)+'
 - name: sequencing_read_percent_q30
   description: Percent of bases with Quality scores above Q30
 - name: sequencing_reagent_kit


### PR DESCRIPTION
This is a slash-delimit4d list of sequencing cycles-
name: sequencing_read_format
  description: Slash-delimited list of the number of sequencing cycles for, for example, Read1, i7 index, i5 index, and Read2.
  constraints:
    pattern: '\d+(/\d+)+'