### PR TITLE
TO DOs done for WGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v0.0.4 - In progress
 ### Added
 - Fill in TODOs.
-- Assay descriptions.
 - Generate unified description list.
 - Links to background docs.
 - Pre-fill enums in TSVs

--- a/docs/field-descriptions.yaml
+++ b/docs/field-descriptions.yaml
@@ -194,8 +194,8 @@ section_prep_protocols_io_doi: TODO
 segment_data_format: Numerical data type. TODO - Not sure this is actually a number...
   Do they mean the format of the data, like "16-bit little endian"?
 sequencing_phix_percent: Percent PhiX loaded to the ru
-sequencing_read_format: Number of sequencing cycles in Read1, i7 index, i5 index,
-  and Read2 (R1/i7/i5/R2). TODO - pattern constraint.
+sequencing_read_format: Slash-delimited list of the number of sequencing cycles for,
+  for example, Read1, i7 index, i5 index, and Read2.
 sequencing_read_percent_q30: Percent of bases with Quality scores above Q30
 sequencing_reagent_kit: Reagent kit used for sequencing
 signal_type: Type of signal measured per channel (usually dual counts)

--- a/docs/wgs/README.md
+++ b/docs/wgs/README.md
@@ -214,10 +214,11 @@ State whether the library was generated for single-end or paired end sequencing.
 | required | `True` |
 
 ### `library_adapter_sequence`
-Adapter sequence to be used for adapter trimming. TODO - pattern
+The adapter sequence to be used for adapter trimming starting with the 5' end. (eg. 5-ATCCTGAGAA)
 
 | constraint | value |
 | --- | --- |
+| pattern (regular expression) | `5-[GATCU]+` |
 | required | `True` |
 
 ### `library_final_yield`
@@ -252,10 +253,11 @@ Reagent kit used for sequencing
 | required | `True` |
 
 ### `sequencing_read_format`
-Number of sequencing cycles in Read1, i7 index, i5 index, and Read2 (R1/i7/i5/R2). TODO - pattern constraint.
+Slash-delimited list of the number of sequencing cycles for, for example, Read1, i7 index, i5 index, and Read2.
 
 | constraint | value |
 | --- | --- |
+| pattern (regular expression) | `\d+(/\d+)+` |
 | required | `True` |
 
 ### `sequencing_read_percent_q30`

--- a/docs/wgs/unified.yaml
+++ b/docs/wgs/unified.yaml
@@ -125,8 +125,10 @@ fields:
     sequencing.
   name: library_layout
 - constraints:
+    pattern: 5-[GATCU]+
     required: true
-  description: Adapter sequence to be used for adapter trimming. TODO - pattern
+  description: The adapter sequence to be used for adapter trimming starting with
+    the 5' end. (eg. 5-ATCCTGAGAA)
   name: library_adapter_sequence
 - constraints:
     required: true
@@ -150,9 +152,10 @@ fields:
   description: Reagent kit used for sequencing
   name: sequencing_reagent_kit
 - constraints:
+    pattern: \d+(/\d+)+
     required: true
-  description: Number of sequencing cycles in Read1, i7 index, i5 index, and Read2
-    (R1/i7/i5/R2). TODO - pattern constraint.
+  description: Slash-delimited list of the number of sequencing cycles for, for example,
+    Read1, i7 index, i5 index, and Read2.
   name: sequencing_read_format
 - constraints:
     maximum: 100

--- a/src/ingest_validation_tools/table-schemas/level-2/wgs.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-2/wgs.yaml
@@ -55,7 +55,9 @@ fields:
       - single-end
       - paired-end
 - name: library_adapter_sequence
-  description: Adapter sequence to be used for adapter trimming. TODO - pattern
+  description: The adapter sequence to be used for adapter trimming starting with the 5' end. (eg. 5-ATCCTGAGAA)
+  constraints:
+    pattern: '5-[GATCU]+'
 - name: library_final_yield
   description: Total amount of library after final pcr amplification step
   type: number
@@ -71,8 +73,9 @@ fields:
 - name: sequencing_reagent_kit
   description: Reagent kit used for sequencing
 - name: sequencing_read_format
-  description: Number of sequencing cycles in Read1, i7 index, i5 index, and Read2
-    (R1/i7/i5/R2). TODO - pattern constraint.
+  description: Slash-delimited list of the number of sequencing cycles for, for example, Read1, i7 index, i5 index, and Read2.
+  constraints:
+    pattern: '\d+(/\d+)+'
 - name: sequencing_read_percent_q30
   description: Percent of bases with Quality scores above Q30
 - name: sequencing_phix_percent


### PR DESCRIPTION
library_adapter_sequence
  description: The adapter sequence to be used for adapter trimming starting with the 5' end. (eg. 5-ATCCTGAGAA)
  constraints:
    pattern: '5-[GATCU]+'

sequencing_read_format
  description: Slash-delimited list of the number of sequencing cycles for, for example, Read1, i7 index, i5 index, and Read2.
  constraints:
    pattern: '\d+(/\d+)+'