### PR TITLE
Dir schema now allows descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Change "mixif" to "mxif".
 - Expose sample field descriptions for use in portal.
 - Add missing assay type to enum.
+- Dicts at the bottom of the directory schema, so we can have a description for each file.
 
 ## v0.0.4 - 2020-06-26
 ### Added

--- a/src/ingest_validation_tools/directory-schemas/af.yaml
+++ b/src/ingest_validation_tools/directory-schemas/af.yaml
@@ -1,20 +1,20 @@
 LC Data:
-  '*': 0 # TODO: What is expected here?
+  '*': { required: False, description: "TODO" } # TODO: What is expected here?
 metadata:
   assay:
-    AF.csv: 1
+    AF.csv: { description: "TODO" }
 templates:
-  '*': 0 # TODO: What is expected here?
+  '*': { required: False, description: "TODO" } # TODO: What is expected here?
 VAN*-*K-*-*_*:
   CCF Metadata:
-    VAN*-*K-*-*_ccf_metadata: 1
+    VAN*-*K-*-*_ccf_metadata: { description: "TODO" }
   VAN*-*K-*-*_*-AF:
     processedMicroscopy:
       VAN*-*K-*-*-AF_preIMS_images:
-        VAN*-*K-*-*-AF_preIMS_registered.ome.tiff: 1
-      VAN*-*K-*-*-AF_preIMS_transformations: 1
-        transform_00_VAN*-*K-*-*-AF_preIMS_rigid.txt: 1
-        transform_01_VAN*-*K-*-*-AF_preIMS_affine.txt: 1
+        VAN*-*K-*-*-AF_preIMS_registered.ome.tiff: { description: "TODO" }
+      VAN*-*K-*-*-AF_preIMS_transformations: { description: "TODO" }
+        transform_00_VAN*-*K-*-*-AF_preIMS_rigid.txt: { description: "TODO" }
+        transform_01_VAN*-*K-*-*-AF_preIMS_affine.txt: { description: "TODO" }
       rawMicroscopy:
-        VAN*-*K-*-*-AF_preIMS_meta_unregistered.xml: 1
-        VAN*-*K-*-*-AF_preIMS_unregistered.czi: 1
+        VAN*-*K-*-*-AF_preIMS_meta_unregistered.xml: { description: "TODO" }
+        VAN*-*K-*-*-AF_preIMS_unregistered.czi: { description: "TODO" }

--- a/src/ingest_validation_tools/directory-schemas/bulkatacseq.yaml
+++ b/src/ingest_validation_tools/directory-schemas/bulkatacseq.yaml
@@ -1,2 +1,2 @@
-'*.fastq.gz': 1
+'*.fastq.gz': { description: "TODO" }
 # TODO: Handle ancillary files... but clarify what we should accept.

--- a/src/ingest_validation_tools/directory-schemas/bulkrnaseq.yaml
+++ b/src/ingest_validation_tools/directory-schemas/bulkrnaseq.yaml
@@ -1,2 +1,2 @@
-'**': 0
+'**': { required: False, description: "TODO" }
 # TODO: No file structure obvious at https://docs.google.com/document/d/1gRPGWWO43nSY024NHuQ4RdONTRezhI0tPOcZyCsvHhI/edit

--- a/src/ingest_validation_tools/directory-schemas/codex-akoya.yaml
+++ b/src/ingest_validation_tools/directory-schemas/codex-akoya.yaml
@@ -1,10 +1,10 @@
 # A description of Akoya CODEX dataset directories.
 # Based on the description at https://docs.google.com/document/d/1CYYSXPQjwdbvmvZaEcsi_2udvDfGEZrMyh4yFnm4p3M/edit#heading=h.h6zxv8ghthzp
 
-channelnames.txt: 1
-experiment.json: 1
-exposure_times.txt: 1
-segmentation.json: 0
+channelnames.txt: { description: "TODO" }
+experiment.json: { description: "TODO" }
+exposure_times.txt: { description: "TODO" }
+segmentation.json: { required: False, description: "TODO" }
 cyc*_reg*_*:
-  '*_*_Z*_CH*': 1
-  '*.gci': 0
+  '*_*_Z*_CH*': { description: "TODO" }
+  '*.gci': { required: False, description: "TODO" }

--- a/src/ingest_validation_tools/directory-schemas/codex-stanford.yaml
+++ b/src/ingest_validation_tools/directory-schemas/codex-stanford.yaml
@@ -1,9 +1,9 @@
 # A description of Stanford CODEX dataset directories.
 # Based on the description at https://docs.google.com/document/d/1CYYSXPQjwdbvmvZaEcsi_2udvDfGEZrMyh4yFnm4p3M/edit#heading=h.h6zxv8ghthzp
 
-channelNames.txt: 1
-Experiment.json: 1
-exposure_times.txt: 1
-processingOptions.json: 1
+channelNames.txt: { description: "TODO" }
+Experiment.json: { description: "TODO" }
+exposure_times.txt: { description: "TODO" }
+processingOptions.json: { description: "TODO" }
 Cyc*_reg*:
-  'HE_*_Z*_CH*': 1
+  'HE_*_Z*_CH*': { description: "TODO" }

--- a/src/ingest_validation_tools/directory-schemas/imc.yaml
+++ b/src/ingest_validation_tools/directory-schemas/imc.yaml
@@ -1,4 +1,4 @@
-'**': 0
+'**': { required: False, description: "TODO" }
 # TODO: On https://docs.google.com/document/d/1NvYmjxICLCU7D62Yd5C_4gUGuDwJ9g89BV6j5s8Atro/edit#heading=h.ef5exhvrbw5z
 # text is grey - Does it apply?
 # Is IMC a kind of CODEX? The CODEX file organization diagram is used in the document above.

--- a/src/ingest_validation_tools/directory-schemas/lcms.yaml
+++ b/src/ingest_validation_tools/directory-schemas/lcms.yaml
@@ -1,3 +1,3 @@
-'**': 0
+'**': { required: False, description: "TODO" }
 # TODO: https://docs.google.com/document/d/1TQpBaIkkCGztGeEFTAjgXuOaPOPeDG-uOcoQ9oiIyfc/edit#heading=h.3325yk694srm
 # File types of different data states are listed: Can anything more precise be said?

--- a/src/ingest_validation_tools/directory-schemas/maldiims.yaml
+++ b/src/ingest_validation_tools/directory-schemas/maldiims.yaml
@@ -1,33 +1,33 @@
 CCF Metadata:
-  VAN*-*K-*-*_ccf_metadata: 1
+  VAN*-*K-*-*_ccf_metadata: { description: "TODO" }
 VAN*-*K-*-*_*-IMS:
   VAN*-*K-*-*_*-IMS_NegMode:
     csv:
-      VAN*-*K-*-*_*-IMS_NegMode_columnar.csv: 1
+      VAN*-*K-*-*_*-IMS_NegMode_columnar.csv: { description: "TODO" }
     imzML:
-      VAN*-*K-*-*_*-IMS_NegMode.ibd: 1
-      VAN*-*K-*-*_*-IMS_NegMode.imzML: 1
+      VAN*-*K-*-*_*-IMS_NegMode.ibd: { description: "TODO" }
+      VAN*-*K-*-*_*-IMS_NegMode.imzML: { description: "TODO" }
     metadata:
-      VAN*-*K-*-*_*-IMS_NegMode_meta.json: 1
-      VAN*-*K-*-*_*-IMS_NegMode_tform_to_microscopy.txt: 1
-      VAN*-*K-*-*_*-IMS_NegMode_LipidAssignments.xlsx: 1
+      VAN*-*K-*-*_*-IMS_NegMode_meta.json: { description: "TODO" }
+      VAN*-*K-*-*_*-IMS_NegMode_tform_to_microscopy.txt: { description: "TODO" }
+      VAN*-*K-*-*_*-IMS_NegMode_LipidAssignments.xlsx: { description: "TODO" }
     ometiffs:
-      VAN*-*K-*-*_*-IMS_NegMode_multilayer.ome.tiff: 1
+      VAN*-*K-*-*_*-IMS_NegMode_multilayer.ome.tiff: { description: "TODO" }
       separate:
         # Individual ome.tiff files for each ion.
-        '*.ome.tiff': 1
+        '*.ome.tiff': { description: "TODO" }
   VAN*-*K-*-*_*-IMS_PosMode:
     csv:
-      VAN*-*K-*-*_*-IMS_PosMode_columnar.csv: 1
+      VAN*-*K-*-*_*-IMS_PosMode_columnar.csv: { description: "TODO" }
     imzML:
-      VAN*-*K-*-*_*-IMS_PosMode.ibd: 1
-      VAN*-*K-*-*_*-IMS_PosMode.imzML: 1
+      VAN*-*K-*-*_*-IMS_PosMode.ibd: { description: "TODO" }
+      VAN*-*K-*-*_*-IMS_PosMode.imzML: { description: "TODO" }
     metadata:
-      VAN*-*K-*-*_*-IMS_PosMode_meta.json: 1
-      VAN*-*K-*-*_*-IMS_PosMode_tform_to_microscopy.txt: 1
-      VAN*-*K-*-*_*-IMS_PosMode_LipidAssignments.xlsx: 1
+      VAN*-*K-*-*_*-IMS_PosMode_meta.json: { description: "TODO" }
+      VAN*-*K-*-*_*-IMS_PosMode_tform_to_microscopy.txt: { description: "TODO" }
+      VAN*-*K-*-*_*-IMS_PosMode_LipidAssignments.xlsx: { description: "TODO" }
     ometiffs:
-      VAN*-*K-*-*_*-IMS_PosMode_multilayer.ome.tiff: 1
+      VAN*-*K-*-*_*-IMS_PosMode_multilayer.ome.tiff: { description: "TODO" }
       separate:
         # Individual ome.tiff files for each ion.
-        '*.ome.tiff': 1
+        '*.ome.tiff': { description: "TODO" }

--- a/src/ingest_validation_tools/directory-schemas/mxif.yaml
+++ b/src/ingest_validation_tools/directory-schemas/mxif.yaml
@@ -1,22 +1,22 @@
 LC Data:
-  '*': 0 # TODO: What is expected here?
+  '*': { required: False, description: "TODO" } # TODO: What is expected here?
 metadata:
   assay:
-    MxIF.csv: 1
+    MxIF.csv: { description: "TODO" }
 templates:
-  '*': 0 # TODO: What is expected here?
+  '*': { required: False, description: "TODO" } # TODO: What is expected here?
 VAN*-*K-*-*_*:
   CCF Metadata:
-    VAN*-*K-*-*_ccf_metadata: 1
+    VAN*-*K-*-*_ccf_metadata: { description: "TODO" }
   VAN*-*K-*-*_*-MxIF:
     processedMicroscopy:
       VAN*-*K-*-*-MxIF_cycl*_images:
         # TODO: Is "cyc1" correct below?
-        VAN*-*K-*-*-MxIF_cyc1_registered.ome.tiff: 1
-      VAN*-*K-*-*-MxIF_cycl*_transformations: 1
-        transform_00_VAN*-*K-*-*-MxIF_cycl*_rigid.txt: 1
-        transform_01_VAN*-*K-*-*-MxIF_cycl*_affine.txt: 1
+        VAN*-*K-*-*-MxIF_cyc1_registered.ome.tiff: { description: "TODO" }
+      VAN*-*K-*-*-MxIF_cycl*_transformations: { description: "TODO" }
+        transform_00_VAN*-*K-*-*-MxIF_cycl*_rigid.txt: { description: "TODO" }
+        transform_01_VAN*-*K-*-*-MxIF_cycl*_affine.txt: { description: "TODO" }
       rawMicroscopy:
         # NOTE: Original document has "cyc*" below.
-        VAN*-*K-*-*-MxIF_cycl*_meta_unregistered.xml: 1
-        VAN*-*K-*-*-MxIF_cycl*_unregistered.czi: 1
+        VAN*-*K-*-*-MxIF_cycl*_meta_unregistered.xml: { description: "TODO" }
+        VAN*-*K-*-*-MxIF_cycl*_unregistered.czi: { description: "TODO" }

--- a/src/ingest_validation_tools/directory-schemas/scatacseq.yaml
+++ b/src/ingest_validation_tools/directory-schemas/scatacseq.yaml
@@ -1,2 +1,2 @@
-'*.fastq.gz': 1
+'*.fastq.gz': { description: "TODO" }
 # TODO: Handle ancillary files... but clarify what we should accept.

--- a/src/ingest_validation_tools/directory-schemas/scrnaseq.yaml
+++ b/src/ingest_validation_tools/directory-schemas/scrnaseq.yaml
@@ -1,2 +1,2 @@
-'**': 0
+'**': { required: False, description: "TODO" }
 # TODO: No file structure obvious at https://docs.google.com/document/d/1gRPGWWO43nSY024NHuQ4RdONTRezhI0tPOcZyCsvHhI/edit

--- a/src/ingest_validation_tools/directory-schemas/seqfish.yaml
+++ b/src/ingest_validation_tools/directory-schemas/seqfish.yaml
@@ -1,2 +1,2 @@
 HybCycle_*:
-  MMStack_Pos*.ome.tif: 1
+  MMStack_Pos*.ome.tif: { description: "TODO" }

--- a/src/ingest_validation_tools/directory-schemas/stained.yaml
+++ b/src/ingest_validation_tools/directory-schemas/stained.yaml
@@ -1,22 +1,22 @@
 LC Data:
-  '*': 0 # TODO: What is expected here?
+  '*': { required: False, description: "TODO" } # TODO: What is expected here?
 metadata:
   assay:
-    PAS.csv: 1
+    PAS.csv: { description: "TODO" }
 templates:
-  '*': 0 # TODO: What is expected here?
+  '*': { required: False, description: "TODO" } # TODO: What is expected here?
 VAN*-*K-*-*_*:
   CCF Metadata:
-    VAN*-*K-*-*_ccf_metadata: 1
+    VAN*-*K-*-*_ccf_metadata: { description: "TODO" }
   VAN*-*K-*-*_*-PAS:
     processedMicroscopy:
       VAN*-*K-*-*-PAS_images:
-        VAN*-*K-*-*-PAS_registered.ome.tiff: 1
+        VAN*-*K-*-*-PAS_registered.ome.tiff: { description: "TODO" }
       VAN*-*K-*-*-PAS_transformations:
-        transform_00_VAN000*-*K-*-*-PAS_initial.txt: 1
-        transform_00_VAN000*-*K-*-*-PAS_rigid.txt: 1
-        transform_00_VAN000*-*K-*-*-PAS_append_rigid.txt: 1
-        transform_01_VAN000*-*K-*-*-PAS_affine.txt: 1
+        transform_00_VAN000*-*K-*-*-PAS_initial.txt: { description: "TODO" }
+        transform_00_VAN000*-*K-*-*-PAS_rigid.txt: { description: "TODO" }
+        transform_00_VAN000*-*K-*-*-PAS_append_rigid.txt: { description: "TODO" }
+        transform_01_VAN000*-*K-*-*-PAS_affine.txt: { description: "TODO" }
       rawMicroscopy:
-        VAN*-*K-*-*-PAS_meta_unregistered.xml: 1
-        VAN*-*K-*-*-PAS_unregistered.czi: 1
+        VAN*-*K-*-*-PAS_meta_unregistered.xml: { description: "TODO" }
+        VAN*-*K-*-*-PAS_unregistered.czi: { description: "TODO" }

--- a/src/ingest_validation_tools/directory-schemas/wgs.yaml
+++ b/src/ingest_validation_tools/directory-schemas/wgs.yaml
@@ -1,3 +1,3 @@
-'**': 0
+'**': { required: False, description: "TODO" }
 # TODO: https://docs.google.com/document/d/117ytDDuez03mdcRqzenLv0l7PyQ-7GWh_1wHEOJZxiI/edit#
 # does not suggest directory structure.

--- a/src/ingest_validation_tools/directory_validator.py
+++ b/src/ingest_validation_tools/directory_validator.py
@@ -48,12 +48,12 @@ def validate_directory(path, paths_dict, dataset_ignore_globs=[]):
 
 def _get_required_allowed(nested):
     '''
-    Given a nested dict, flatten it and separate the keys with
-    falsy values from those with truthy values.
+    Given a nested dict, flatten it and separate the keys
+    which are required from those that are allowed.
 
     >>> nested = {
-    ...   'a': 1,
-    ...   'b': {'c': 0}
+    ...   'a': {'description': 'A'},
+    ...   'b': {'c': {'required': False, 'description': 'C'}}
     ... }
     >>> _get_required_allowed(nested)
     (['a'], ['a', 'b/c'])
@@ -64,31 +64,34 @@ def _get_required_allowed(nested):
     allowed = []
     for k, v in flat.items():
         allowed.append(k)
-        if v:
+        if 'required' not in v or v['required']:
             required.append(k)
     return required, allowed
 
 
 def _flatten(nested, joiner='/'):
     '''
-    Given a nested dict, flatten it to a single layer dict,
+    Given a nested dict, flatten it to a two layer dict,
     with keys constructed by chaining the keys of the original.
 
     >>> nested = {
-    ...   'x.txt': 1,
+    ...   'x.txt': {'description': 'X'},
     ...   'a': {
-    ...     'y.txt': 0,
+    ...     'y.txt': {'required': False, 'description': 'Y'},
     ...     'b': {
     ...       'c': {},
     ...       'd': {
-    ...         'z.txt': 1 }}}}
-    >>> _flatten(nested)
-    {'x.txt': 1, 'a/y.txt': 0, 'a/b/d/z.txt': 1}
+    ...         'z.txt': {'description': 'Z'} }}}}
+    >>> from pprint import pprint
+    >>> pprint(_flatten(nested))
+    {'a/b/d/z.txt': {'description': 'Z'},
+     'a/y.txt': {'description': 'Y', 'required': False},
+     'x.txt': {'description': 'X'}}
 
     '''
     flat = {}
     for key, value in nested.items():
-        if type(value) != dict:
+        if 'description' in value:
             flat[key] = value
         else:
             for k, v in _flatten(value).items():


### PR DESCRIPTION
Fix #346.

Background: The first attempt at a "directory schema" serialized directories to a json structure, and then used json schema to validate. That didn't work well:
- Schemas hard to author.
- Schemas hard to read.
- Errors hard to interpret.

The second version gave up some flexibility, but is vastly improved in all three areas. Directory schemas are now nested yaml dicts, with globbing allowed on filenames where there will be variation.

Before this PR, at the leafs, we had either `0` or `1` for optional or required, but we want to record descriptions at least, and in the future indicate whether a particular file provides a QA report.

Questions:
- The code looks for `description` to know that a dict is a description of a file, and not a subdirectory. This would prevent `description` from being used as the name of a file. Ok?
- Optional files are indicated with `required: False`? It could just as easily be `optional: True`. Any preference?
- There are a lot of TODOs to fill in, and for many assay types we don't have schemas. @cebriggs7135 : Do you think it is feasible to get these filled in, or does it feel like we're digging ourselves into a hole?
- Do you think you'll want to support markdown in the descriptions? If so, I would like to change the field name to `description_md`.