### PR TITLE
validate_submission.py gets command line arg to specify plugin dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Contributors table schema.
 - Add extra validation hooks.
 - Add nano docs.
+- Run plugin tests only from command line argument
 
 ## v0.0.4 - 2020-06-26
 ### Added

--- a/README-validate_submission.py.md
+++ b/README-validate_submission.py.md
@@ -7,6 +7,7 @@ usage: validate_submission.py [-h]
                               [--submission_ignore_globs GLOB [GLOB ...]]
                               [--output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}]
                               [--add_notes]
+                              [--plugin_dir_abs_path PLUGIN_DIR_ABS_PATH]
 
 Validate a HuBMAP submission, both the metadata TSVs, and the datasets,
 either local or remote, or a combination of the two.
@@ -36,6 +37,8 @@ optional arguments:
                         ignored.
   --output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}
   --add_notes           Append a context note to error reports.
+  --plugin_dir_abs_path PLUGIN_DIR_ABS_PATH
+                        Absolute path of a directory of plugin tests.
 
 Typical usecases:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ tableschema==1.15.0
 goodtables==2.4.9
 globus-cli==1.12.0
 yattag==1.14.0
-xmltodict>=0.12.0
-tifffile>=2020.10.1

--- a/src/ingest_validation_tools/submission.py
+++ b/src/ingest_validation_tools/submission.py
@@ -11,7 +11,10 @@ from ingest_validation_tools.validation_utils import (
     get_contributors_errors
 )
 
-from ingest_validation_tools.plugin_validator import run_plugin_validators_iter
+from ingest_validation_tools.plugin_validator import (
+    run_plugin_validators_iter,
+    ValidatorError as PluginValidatorError
+)
 
 
 def _get_directory_type_from_path(path):
@@ -82,9 +85,12 @@ class Submission:
         if plugin_path:
             errors = defaultdict(list)
             for metadata_path in self.effective_tsv_paths.values():
-                for k, v in run_plugin_validators_iter(metadata_path,
-                                                       plugin_path):
-                    errors[k].append(v)
+                try:
+                    for k, v in run_plugin_validators_iter(metadata_path,
+                                                           plugin_path):
+                        errors[k].append(v)
+                except PluginValidatorError as e:
+                    errors['Unexpected Plugin Error'] = str(e)
             return {k: v for k, v in errors.items()}  # get rid of defaultdict
         else:
             return {}

--- a/src/validate_submission.py
+++ b/src/validate_submission.py
@@ -161,7 +161,6 @@ def main():
         submission_args['submission_ignore_globs'] = \
             args.submission_ignore_globs
 
-
     if args.plugin_dir_abs_path:
         submission_args['plugin_dir_abs_path'] = \
             args.plugin_dir_abs_path

--- a/src/validate_submission.py
+++ b/src/validate_submission.py
@@ -95,6 +95,10 @@ Typical usecases:
     parser.add_argument('--add_notes', action='store_true',
                         help='Append a context note to error reports.')
 
+    # Permit the user to set the location of the plugin directory
+    parser.add_argument('--plugin_dir_abs_path', action='store',
+                        help='Absolute path of a directory of plugin tests.')
+
     return parser
 
 
@@ -156,6 +160,11 @@ def main():
     if args.submission_ignore_globs:
         submission_args['submission_ignore_globs'] = \
             args.submission_ignore_globs
+
+
+    if args.plugin_dir_abs_path:
+        submission_args['plugin_dir_abs_path'] = \
+            args.plugin_dir_abs_path
 
     submission = Submission(**submission_args)
     errors = submission.get_errors()


### PR DESCRIPTION
I think the only unexpected bit of code here is that I am treating the command line argument --plugin_dir_abs_path as an explicit request to run the plugins, so the clause skipping the plugins if there are tsv or directory errors has been removed.