### PR TITLE
Regex examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.6 - In progress
+- Add machinery to include regex examples in docs.
 
 ## v0.0.5 - 2020-11-09
 - Change "mixif" to "mxif".

--- a/docs/af/README.md
+++ b/docs/af/README.md
@@ -62,7 +62,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -70,7 +70,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/af/README.md
+++ b/docs/af/README.md
@@ -190,7 +190,7 @@ The unit of measurement of width of a pixel.
 | required | `True` |
 
 ### `resolution_y_value`
-The height of a pixel
+The height of a pixel.
 
 | constraint | value |
 | --- | --- |

--- a/docs/bulkatacseq/README.md
+++ b/docs/bulkatacseq/README.md
@@ -176,7 +176,7 @@ An acquisition_instrument is the device that contains the signal detection hardw
 | required | `True` |
 
 ### `acquisition_instrument_model`
-Manufacturers of an acquisition instrument may offer various versions (models) of that instrument with different features or sensitivities. Differences in features or sensitivities may be relevant to processing or interpretation of the data
+Manufacturers of an acquisition instrument may offer various versions (models) of that instrument with different features or sensitivities. Differences in features or sensitivities may be relevant to processing or interpretation of the data.
 
 | constraint | value |
 | --- | --- |
@@ -190,7 +190,7 @@ A number (no comma separators)
 | required | `True` |
 
 ### `bulk_atac_cell_isolation_protocols_io_doi`
-Link to a protocols document answering the question: How was tissue stored and processed for cell/nuclei isolation
+Link to a protocols document answering the question: How was tissue stored and processed for cell/nuclei isolation.
 
 | constraint | value |
 | --- | --- |
@@ -206,7 +206,7 @@ Is this a sequencing replicate?
 | required | `True` |
 
 ### `library_adapter_sequence`
-Adapter sequence to be used for adapter trimming
+Adapter sequence to be used for adapter trimming.
 
 | constraint | value |
 | --- | --- |
@@ -228,7 +228,7 @@ The concentration value of the pooled library samples submitted for sequencing.
 | required | `True` |
 
 ### `library_concentration_unit`
-Unit of library_concentration_value
+Unit of library_concentration_value.
 
 | constraint | value |
 | --- | --- |
@@ -261,7 +261,7 @@ Total amount (eg. nanograms) of library after the clean-up step of final pcr amp
 | required | `True` |
 
 ### `library_final_yield_unit`
-Units of library final yield
+Units of library final yield.
 
 | constraint | value |
 | --- | --- |
@@ -292,7 +292,7 @@ Number of PCR cycles performed in order to add adapters and amplify the library.
 | required | `True` |
 
 ### `library_preparation_kit`
-Reagent kit used for library preparation
+Reagent kit used for library preparation.
 
 | constraint | value |
 | --- | --- |
@@ -306,7 +306,7 @@ This is a quality metric by visual inspection. This should answer the question: 
 | required | `True` |
 
 ### `sequencing_phix_percent`
-Percent PhiX loaded to the run
+Percent PhiX loaded to the run.
 
 | constraint | value |
 | --- | --- |
@@ -324,7 +324,7 @@ Slash-delimited list of the number of sequencing cycles for, for example, Read1,
 | required | `True` |
 
 ### `sequencing_read_percent_q30`
-Percent of bases with Quality scores above Q30
+Percent of bases with Quality scores above Q30.
 
 | constraint | value |
 | --- | --- |
@@ -334,7 +334,7 @@ Percent of bases with Quality scores above Q30
 | maximum | `100` |
 
 ### `sequencing_reagent_kit`
-Reagent kit used for sequencing. NovaSeq6000 for example
+Reagent kit used for sequencing. NovaSeq6000 for example.
 
 | constraint | value |
 | --- | --- |

--- a/docs/bulkatacseq/README.md
+++ b/docs/bulkatacseq/README.md
@@ -70,7 +70,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -78,7 +78,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/bulkrnaseq/README.md
+++ b/docs/bulkrnaseq/README.md
@@ -178,7 +178,7 @@ An acquisition_instrument is the device that contains the signal detection hardw
 | required | `True` |
 
 ### `bulk_rna_isolation_protocols_io_doi`
-Link to a protocols document answering the question: How was tissue stored and processed for RNA isolation RNA_isolation_protocols_io_doi
+Link to a protocols document answering the question: How was tissue stored and processed for RNA isolation RNA_isolation_protocols_io_doi.
 
 | constraint | value |
 | --- | --- |
@@ -202,7 +202,7 @@ RNA amount per Tissue input amount. Valid values should be weight/weight (ng/mg)
 | required | `True` |
 
 ### `bulk_rna_isolation_quality_metric_value`
-RIN value
+RIN value.
 
 | constraint | value |
 | --- | --- |
@@ -212,7 +212,7 @@ RIN value
 | required | `True` |
 
 ### `rnaseq_assay_input_value`
-RNA input amount value to the assay
+RNA input amount value to the assay.
 
 | constraint | value |
 | --- | --- |
@@ -220,7 +220,7 @@ RNA input amount value to the assay
 | required | `True` |
 
 ### `rnaseq_assay_input_unit`
-Units of RNA input amount to the assay
+Units of RNA input amount to the assay.
 
 | constraint | value |
 | --- | --- |
@@ -259,7 +259,7 @@ Adapter sequence to be used for adapter trimming.
 | required | `True` |
 
 ### `library_pcr_cycles_for_sample_index`
-Number of PCR cycles performed for library indexing
+Number of PCR cycles performed for library indexing.
 
 | constraint | value |
 | --- | --- |
@@ -267,7 +267,7 @@ Number of PCR cycles performed for library indexing
 | required | `True` |
 
 ### `library_final_yield_value`
-Total amount of library after final pcr amplification step
+Total amount of library after final pcr amplification step.
 
 | constraint | value |
 | --- | --- |
@@ -275,7 +275,7 @@ Total amount of library after final pcr amplification step
 | required | `True` |
 
 ### `library_final_yield_unit`
-units of library final yield
+units of library final yield.
 
 | constraint | value |
 | --- | --- |
@@ -291,7 +291,7 @@ Average size in base pairs (bp) of sequencing library fragments estimated via ge
 | required | `True` |
 
 ### `sequencing_reagent_kit`
-Reagent kit used for sequencing
+Reagent kit used for sequencing.
 
 | constraint | value |
 | --- | --- |
@@ -306,7 +306,7 @@ Slash-delimited list of the number of sequencing cycles for, for example, Read1,
 | required | `True` |
 
 ### `sequencing_read_percent_q30`
-Percent of bases with Quality scores above Q30
+Percent of bases with Quality scores above Q30.
 
 | constraint | value |
 | --- | --- |
@@ -316,7 +316,7 @@ Percent of bases with Quality scores above Q30
 | maximum | `100` |
 
 ### `sequencing_phix_percent`
-Percent PhiX loaded to the run
+Percent PhiX loaded to the run.
 
 | constraint | value |
 | --- | --- |

--- a/docs/bulkrnaseq/README.md
+++ b/docs/bulkrnaseq/README.md
@@ -65,7 +65,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -73,7 +73,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -85,7 +85,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -93,7 +93,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -258,7 +258,7 @@ The manufacturer of the instrument used to prepare the sample for the assay.
 | required | `True` |
 
 ### `preparation_instrument_model`
-The model number/name of the instrument used to prepare the sample for the assay
+The model number/name of the instrument used to prepare the sample for the assay.
 
 | constraint | value |
 | --- | --- |
@@ -266,7 +266,7 @@ The model number/name of the instrument used to prepare the sample for the assay
 | required | `True` |
 
 ### `number_of_antibodies`
-Number of antibodies
+Number of antibodies.
 
 | constraint | value |
 | --- | --- |
@@ -282,7 +282,7 @@ Number of fluorescent channels imaged during each cycle.
 | required | `True` |
 
 ### `number_of_cycles`
-Number of cycles of 1. oligo application, 2. fluor application, 3. washes
+Number of cycles of 1. oligo application, 2. fluor application, 3. washes.
 
 | constraint | value |
 | --- | --- |

--- a/docs/imc/README.md
+++ b/docs/imc/README.md
@@ -71,7 +71,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -79,7 +79,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/imc/README.md
+++ b/docs/imc/README.md
@@ -191,7 +191,7 @@ The manufacturer of the instrument used to prepare the sample for the assay.
 | required | `True` |
 
 ### `preparation_instrument_model`
-The model number/name of the instrument used to prepare the sample for the assay
+The model number/name of the instrument used to prepare the sample for the assay.
 
 | constraint | value |
 | --- | --- |
@@ -214,7 +214,7 @@ DOI for protocols.io referring to the protocol for preparing reagents for the as
 | pattern (regular expression) | `10\.17504/.*` |
 
 ### `number_of_channels`
-Number of mass channels measured
+Number of mass channels measured.
 
 | constraint | value |
 | --- | --- |
@@ -262,7 +262,7 @@ Frequency value of laser ablation (in Hz)
 | required | `True` |
 
 ### `ablation_frequency_unit`
-Frequency unit of laser ablation
+Frequency unit of laser ablation.
 
 | constraint | value |
 | --- | --- |
@@ -300,7 +300,7 @@ Threshold for dual counting.
 | required | `True` |
 
 ### `end_datetime`
-Time stamp indicating end of ablation for ROI
+Time stamp indicating end of ablation for ROI.
 
 | constraint | value |
 | --- | --- |
@@ -309,7 +309,7 @@ Time stamp indicating end of ablation for ROI
 | required | `True` |
 
 ### `max_x_width_value`
-Image width value of the ROI acquisition
+Image width value of the ROI acquisition.
 
 | constraint | value |
 | --- | --- |
@@ -317,7 +317,7 @@ Image width value of the ROI acquisition
 | required | `True` |
 
 ### `max_x_width_unit`
-Units of image width of the ROI acquisition
+Units of image width of the ROI acquisition.
 
 | constraint | value |
 | --- | --- |
@@ -325,7 +325,7 @@ Units of image width of the ROI acquisition
 | required | `True` |
 
 ### `max_y_height_value`
-Image height value of the ROI acquisition
+Image height value of the ROI acquisition.
 
 | constraint | value |
 | --- | --- |
@@ -333,7 +333,7 @@ Image height value of the ROI acquisition
 | required | `True` |
 
 ### `max_y_height_unit`
-Units of image height of the ROI acquisition
+Units of image height of the ROI acquisition.
 
 | constraint | value |
 | --- | --- |
@@ -357,7 +357,7 @@ Type of signal measured per channel (usually dual counts)
 | required | `True` |
 
 ### `start_datetime`
-Time stamp indicating start of ablation for ROI
+Time stamp indicating start of ablation for ROI.
 
 | constraint | value |
 | --- | --- |
@@ -366,7 +366,7 @@ Time stamp indicating start of ablation for ROI
 | required | `True` |
 
 ### `data_precision_bytes`
-Numerical data precision in bytes
+Numerical data precision in bytes.
 
 | constraint | value |
 | --- | --- |

--- a/docs/lcms/README.md
+++ b/docs/lcms/README.md
@@ -246,42 +246,42 @@ Sample preparation methods.
 | pattern (regular expression) | `10\.17504/.*` |
 
 ### `lc_instrument_vendor`
-The manufacturer of the instrument used for LC
+The manufacturer of the instrument used for LC.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `lc_instrument_model`
-The model number/name of the instrument used for LC
+The model number/name of the instrument used for LC.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `lc_column_vendor`
-OPTIONAL: The manufacturer of the LC Column unless self-packed, pulled tip capilary is used
+OPTIONAL: The manufacturer of the LC Column unless self-packed, pulled tip capilary is used.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `lc_column_model`
-The model number/name of the LC Column - IF custom self-packed, pulled tip calillary is used enter "Pulled tip capilary"
+The model number/name of the LC Column - IF custom self-packed, pulled tip calillary is used enter "Pulled tip capilary".
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `lc_resin`
-Details of the resin used for lc, including vendor, particle size, pore size
+Details of the resin used for lc, including vendor, particle size, pore size.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `lc_length_value`
-LC column length
+LC column length.
 
 | constraint | value |
 | --- | --- |
@@ -297,7 +297,7 @@ units for LC column length (typically cm)
 | required | `True` |
 
 ### `lc_temp_value`
-LC temperature
+LC temperature.
 
 | constraint | value |
 | --- | --- |
@@ -305,7 +305,7 @@ LC temperature
 | required | `True` |
 
 ### `lc_temp_unit`
-units for LC temperature
+units for LC temperature.
 
 | constraint | value |
 | --- | --- |
@@ -345,28 +345,28 @@ Units of flow rate. Leave blank if not applicable.
 | enum | `nL/min` or `mL/min` |
 
 ### `lc_gradient`
-LC gradient
+LC gradient.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `lc_mobile_phase_a`
-Composition of mobile phase A
+Composition of mobile phase A.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `lc_mobile_phase_b`
-Composition of mobile phase B
+Composition of mobile phase B.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `processing_search`
-Software for analyzing and searching LC-MS/MS omics data
+Software for analyzing and searching LC-MS/MS omics data.
 
 | constraint | value |
 | --- | --- |

--- a/docs/lcms/README.md
+++ b/docs/lcms/README.md
@@ -74,7 +74,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -82,7 +82,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/maldiims/README.md
+++ b/docs/maldiims/README.md
@@ -167,7 +167,7 @@ Specifies whether or not a specific molecule(s) is/are targeted for detection/me
 ## Level 2
 
 ### `acquisition_instrument_vendor`
-An acquisition instrument is the device that contains the signal detection hardware and signal processing software. Assays generate signals such as light of various intensities or color or signals representing the molecular mass
+An acquisition instrument is the device that contains the signal detection hardware and signal processing software. Assays generate signals such as light of various intensities or color or signals representing the molecular mass.
 
 | constraint | value |
 | --- | --- |
@@ -197,7 +197,7 @@ The polarity of the mass analysis (positive or negative ion modes)
 | required | `True` |
 
 ### `mz_range_low_value`
-A number representing the mass:charge ratio
+A number representing the mass:charge ratio.
 
 | constraint | value |
 | --- | --- |
@@ -205,7 +205,7 @@ A number representing the mass:charge ratio
 | required | `True` |
 
 ### `mz_range_high_value`
-A number representing the mass:charge ratio
+A number representing the mass:charge ratio.
 
 | constraint | value |
 | --- | --- |
@@ -213,7 +213,7 @@ A number representing the mass:charge ratio
 | required | `True` |
 
 ### `resolution_x_value`
-The width of a pixel
+The width of a pixel.
 
 | constraint | value |
 | --- | --- |
@@ -221,7 +221,7 @@ The width of a pixel
 | required | `True` |
 
 ### `resolution_x_unit`
-The unit of measurement of the width of a pixel
+The unit of measurement of the width of a pixel.
 
 | constraint | value |
 | --- | --- |
@@ -229,7 +229,7 @@ The unit of measurement of the width of a pixel
 | required | `True` |
 
 ### `resolution_y_value`
-The height of a pixel
+The height of a pixel.
 
 | constraint | value |
 | --- | --- |
@@ -237,7 +237,7 @@ The height of a pixel
 | required | `True` |
 
 ### `resolution_y_unit`
-The unit of measurement of the height of a pixel
+The unit of measurement of the height of a pixel.
 
 | constraint | value |
 | --- | --- |
@@ -259,7 +259,7 @@ The manufacturer of the instrument used to prepare the sample for the assay.
 | required | `True` |
 
 ### `preparation_instrument_model`
-The model number/name of the instrument used to prepare the sample for the assay
+The model number/name of the instrument used to prepare the sample for the assay.
 
 | constraint | value |
 | --- | --- |

--- a/docs/maldiims/README.md
+++ b/docs/maldiims/README.md
@@ -68,7 +68,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -76,7 +76,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/mxif/README.md
+++ b/docs/mxif/README.md
@@ -56,7 +56,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -64,7 +64,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/nano/README.md
+++ b/docs/nano/README.md
@@ -57,7 +57,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -65,7 +65,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/nano/README.md
+++ b/docs/nano/README.md
@@ -156,7 +156,7 @@ Specifies whether or not a specific molecule(s) is/are targeted for detection/me
 ## Level 2
 
 ### `acquisition_instrument_vendor`
-An acquisition instrument is the device that contains the signal detection hardware and signal processing software. Assays generate signals such as light of various intensities or color or signals representing the molecular mass
+An acquisition instrument is the device that contains the signal detection hardware and signal processing software. Assays generate signals such as light of various intensities or color or signals representing the molecular mass.
 
 | constraint | value |
 | --- | --- |
@@ -186,7 +186,7 @@ The polarity of the mass analysis (positive or negative ion modes)
 | required | `True` |
 
 ### `mz_range_low_value`
-A number representing the mass:charge ratio
+A number representing the mass:charge ratio.
 
 | constraint | value |
 | --- | --- |
@@ -194,7 +194,7 @@ A number representing the mass:charge ratio
 | required | `True` |
 
 ### `mz_range_high_value`
-A number representing the mass:charge ratio
+A number representing the mass:charge ratio.
 
 | constraint | value |
 | --- | --- |
@@ -202,7 +202,7 @@ A number representing the mass:charge ratio
 | required | `True` |
 
 ### `resolution_x_value`
-The width of a pixel
+The width of a pixel.
 
 | constraint | value |
 | --- | --- |
@@ -210,7 +210,7 @@ The width of a pixel
 | required | `True` |
 
 ### `resolution_x_unit`
-The unit of measurement of the width of a pixel
+The unit of measurement of the width of a pixel.
 
 | constraint | value |
 | --- | --- |
@@ -218,7 +218,7 @@ The unit of measurement of the width of a pixel
 | required | `True` |
 
 ### `resolution_y_value`
-The height of a pixel
+The height of a pixel.
 
 | constraint | value |
 | --- | --- |
@@ -226,7 +226,7 @@ The height of a pixel
 | required | `True` |
 
 ### `resolution_y_unit`
-The unit of measurement of the height of a pixel
+The unit of measurement of the height of a pixel.
 
 | constraint | value |
 | --- | --- |

--- a/docs/sample/README.md
+++ b/docs/sample/README.md
@@ -57,7 +57,7 @@ Identify the vital state of the donor.
 | enum | `living` or `deceased` |
 
 ### `health_status`
-Patient's baseline physical condition prior to immediate event leading to organ/tissue acquisition. For example, if a relatively healthy patient suffers trauma, and as a result of reparative surgery, a tissue sample is collected, the subject will be deemed “relatively healthy”.   Likewise, a relatively healthy subject may have experienced trauma leading to brain death.  As a result of organ donation, a sample is collected.  In this scenario, the subject is deemed “relatively healthy.”
+Patient's baseline physical condition prior to immediate event leading to organ/tissue acquisition. For example, if a relatively healthy patient suffers trauma, and as a result of reparative surgery, a tissue sample is collected, the subject will be deemed “relatively healthy”.   Likewise, a relatively healthy subject may have experienced trauma leading to brain death.  As a result of organ donation, a sample is collected.  In this scenario, the subject is deemed “relatively healthy.”.
 
 | constraint | value |
 | --- | --- |
@@ -107,7 +107,7 @@ Time interval between cessation of blood flow and cooling to 4C. Leave blank if 
 | required | `False` |
 
 ### `warm_ischemia_time_unit`
-Time unit
+Time unit.
 
 | constraint | value |
 | --- | --- |
@@ -123,7 +123,7 @@ Time interval on ice to the start of preservation protocol. Leave blank if not a
 | required | `False` |
 
 ### `cold_ischemia_time_unit`
-Time unit
+Time unit.
 
 | constraint | value |
 | --- | --- |

--- a/docs/scatacseq/README.md
+++ b/docs/scatacseq/README.md
@@ -350,7 +350,7 @@ Total ng of library after final pcr amplification step.
 | required | `True` |
 
 ### `library_final_yield_unit`
-Units for library_final_yield
+Units for library_final_yield.
 
 | constraint | value |
 | --- | --- |
@@ -366,14 +366,14 @@ Average size of sequencing library fragments estimated via gel electrophoresis o
 | required | `True` |
 
 ### `sequencing_reagent_kit`
-Reagent kit used for sequencing. NovaSeq6000 for example
+Reagent kit used for sequencing. NovaSeq6000 for example.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `sequencing_read_format`
-Number of sequencing cycles in Read1, i7 index, i5 index, and Read2. Eg: for 10X snATAC-seq: 50+8+16+50 (R1,Index,R2,R3). For SNARE-seq2: 75+94+8+75
+Number of sequencing cycles in Read1, i7 index, i5 index, and Read2. Eg: for 10X snATAC-seq: 50+8+16+50 (R1,Index,R2,R3). For SNARE-seq2: 75+94+8+75.
 
 | constraint | value |
 | --- | --- |

--- a/docs/scatacseq/README.md
+++ b/docs/scatacseq/README.md
@@ -74,7 +74,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -82,7 +82,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/scrnaseq/README.md
+++ b/docs/scrnaseq/README.md
@@ -193,7 +193,7 @@ Link to a protocols document answering the question: How were single cells separ
 | pattern (regular expression) | `10\.17504/.*` |
 
 ### `sc_isolation_entity`
-The type of single cell entity derived from isolation protocol
+The type of single cell entity derived from isolation protocol.
 
 | constraint | value |
 | --- | --- |
@@ -221,21 +221,21 @@ A quality metric by visual inspection prior to cell lysis or defined by known pa
 | required | `True` |
 
 ### `sc_isolation_cell_number`
-Total number of cell/nuclei yielded post dissociation and enrichment
+Total number of cell/nuclei yielded post dissociation and enrichment.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `rnaseq_assay_input`
-Number of cell/nuclei input to the assay
+Number of cell/nuclei input to the assay.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `rnaseq_assay_method`
-The kit used for the RNA sequencing assay
+The kit used for the RNA sequencing assay.
 
 | constraint | value |
 | --- | --- |
@@ -250,28 +250,28 @@ A link to the protocol document containing the library construction method (incl
 | pattern (regular expression) | `10\.17504/.*` |
 
 ### `library_layout`
-Whether the library was generated for single-end or paired end sequencing
+Whether the library was generated for single-end or paired end sequencing.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `library_adapter_sequence`
-Adapter sequence to be used for adapter trimming
+Adapter sequence to be used for adapter trimming.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `library_id`
-An id for the library. The id may be text and/or numbers
+An id for the library. The id may be text and/or numbers.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `is_technical_replicate`
-Is the sequencing reaction run in repliucate, TRUE or FALSE
+Is the sequencing reaction run in repliucate, TRUE or FALSE.
 
 | constraint | value |
 | --- | --- |
@@ -279,7 +279,7 @@ Is the sequencing reaction run in repliucate, TRUE or FALSE
 | required | `True` |
 
 ### `cell_barcode_read`
-Which read file contains the cell barcode
+Which read file contains the cell barcode.
 
 | constraint | value |
 | --- | --- |
@@ -293,21 +293,21 @@ Position(s) in the read at which the cell barcode starts.
 | required | `True` |
 
 ### `cell_barcode_size`
-Length of the cell barcode in base pairs
+Length of the cell barcode in base pairs.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `library_pcr_cycles`
-Number of PCR cycles to amplify cDNA
+Number of PCR cycles to amplify cDNA.
 
 | constraint | value |
 | --- | --- |
 | required | `True` |
 
 ### `library_pcr_cycles_for_sample_index`
-Number of PCR cycles performed for library indexing
+Number of PCR cycles performed for library indexing.
 
 | constraint | value |
 | --- | --- |
@@ -322,7 +322,7 @@ Total number of ng of library after final pcr amplification step. This is the co
 | required | `True` |
 
 ### `library_final_yield_unit`
-Units of final library yield
+Units of final library yield.
 
 | constraint | value |
 | --- | --- |
@@ -337,7 +337,7 @@ Average size of sequencing library fragments estimated via gel electrophoresis o
 | required | `True` |
 
 ### `sequencing_reagent_kit`
-Reagent kit used for sequencing
+Reagent kit used for sequencing.
 
 | constraint | value |
 | --- | --- |
@@ -352,7 +352,7 @@ Slash-delimited list of the number of sequencing cycles for, for example, Read1,
 | required | `True` |
 
 ### `sequencing_read_percent_q30`
-Percent of bases with Quality scores above Q30
+Percent of bases with Quality scores above Q30.
 
 | constraint | value |
 | --- | --- |
@@ -362,7 +362,7 @@ Percent of bases with Quality scores above Q30
 | maximum | `100` |
 
 ### `sequencing_phix_percent`
-Percent PhiX loaded to the run
+Percent PhiX loaded to the run.
 
 | constraint | value |
 | --- | --- |

--- a/docs/scrnaseq/README.md
+++ b/docs/scrnaseq/README.md
@@ -72,7 +72,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -80,7 +80,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/seqfish/README.md
+++ b/docs/seqfish/README.md
@@ -63,7 +63,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -71,7 +71,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/seqfish/README.md
+++ b/docs/seqfish/README.md
@@ -231,7 +231,7 @@ The manufacturer of the instrument used to prepare the sample for the assay. In 
 | required | `True` |
 
 ### `preparation_instrument_model`
-The model number/name of the instrument used to prepare the sample for the assay
+The model number/name of the instrument used to prepare the sample for the assay.
 
 | constraint | value |
 | --- | --- |

--- a/docs/stained/README.md
+++ b/docs/stained/README.md
@@ -179,7 +179,7 @@ The width of a pixel.
 | required | `True` |
 
 ### `resolution_x_unit`
-The unit of measurement of width of a pixel
+The unit of measurement of width of a pixel.
 
 | constraint | value |
 | --- | --- |

--- a/docs/stained/README.md
+++ b/docs/stained/README.md
@@ -59,7 +59,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -67,7 +67,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/wgs/README.md
+++ b/docs/wgs/README.md
@@ -61,7 +61,7 @@ Related files:
 ## Provenance
 
 ### `donor_id`
-HuBMAP Display ID of the donor of the assayed tissue.
+HuBMAP Display ID of the donor of the assayed tissue. Example: `ABC123`.
 
 | constraint | value |
 | --- | --- |
@@ -69,7 +69,7 @@ HuBMAP Display ID of the donor of the assayed tissue.
 | required | `True` |
 
 ### `tissue_id`
-HuBMAP Display ID of the assayed tissue.
+HuBMAP Display ID of the assayed tissue. Example: `ABC123-BL-1-2-3_456`.
 
 | constraint | value |
 | --- | --- |

--- a/docs/wgs/README.md
+++ b/docs/wgs/README.md
@@ -182,7 +182,7 @@ Is the gDNA integrity good enough for WGS? This is usually checked through runni
 | required | `True` |
 
 ### `dna_assay_input_value`
-Amount of DNA input into library preparation
+Amount of DNA input into library preparation.
 
 | constraint | value |
 | --- | --- |
@@ -190,7 +190,7 @@ Amount of DNA input into library preparation
 | required | `True` |
 
 ### `dna_assay_input_unit`
-Units of DNA input into library preparation
+Units of DNA input into library preparation.
 
 | constraint | value |
 | --- | --- |
@@ -229,7 +229,7 @@ The adapter sequence to be used for adapter trimming starting with the 5' end. (
 | required | `True` |
 
 ### `library_final_yield`
-Total amount of library after final pcr amplification step
+Total amount of library after final pcr amplification step.
 
 | constraint | value |
 | --- | --- |
@@ -237,7 +237,7 @@ Total amount of library after final pcr amplification step
 | required | `True` |
 
 ### `library_final_yield_unit`
-Total units of library after final pcr amplification step
+Total units of library after final pcr amplification step.
 
 | constraint | value |
 | --- | --- |
@@ -253,7 +253,7 @@ Average size of sequencing library fragments estimated via gel electrophoresis o
 | required | `True` |
 
 ### `sequencing_reagent_kit`
-Reagent kit used for sequencing
+Reagent kit used for sequencing.
 
 | constraint | value |
 | --- | --- |
@@ -268,7 +268,7 @@ Slash-delimited list of the number of sequencing cycles for, for example, Read1,
 | required | `True` |
 
 ### `sequencing_read_percent_q30`
-Percent of bases with Quality scores above Q30
+Percent of bases with Quality scores above Q30.
 
 | constraint | value |
 | --- | --- |
@@ -278,7 +278,7 @@ Percent of bases with Quality scores above Q30
 | maximum | `100` |
 
 ### `sequencing_phix_percent`
-Percent PhiX loaded to the run
+Percent PhiX loaded to the run.
 
 | constraint | value |
 | --- | --- |

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -41,24 +41,26 @@ def _enrich_description(field):
     >>> _enrich_description(bad_field)
     Traceback (most recent call last):
     ...
-    Exception: bad-example's example (123ABC) does not match pattern ([A-Z]+\d+)
+    Exception: bad-example's example (123ABC) does not match pattern ([A-Z]+\\d+)
 
     '''
-    # Some descriptions end with periods; some don't.
-    description = re.sub(r'\.?\s*$', '. ', field['description'])
+    description = field['description'].strip()
+    if description[-1] not in ['.', ')', '?']:
+        description += '.'
     if (
         'constraints' in field
         and 'required' in field['constraints']
         and not field['constraints']['required']
     ):
-        description += 'Leave blank if not applicable. '
+        description += ' Leave blank if not applicable.'
     if 'example' in field:
         if 'constraints' not in field or 'pattern' not in field['constraints']:
             raise Exception(f'{field["name"]} has example but no pattern')
         if not re.match(field['constraints']['pattern'], field['example']):
             raise Exception(
-                f"{field['name']}'s example ({field['example']}) does not match pattern ({field['constraints']['pattern']})")
-        description += f'Example: `{field["example"]}`. '
+                f"{field['name']}'s example ({field['example']}) "
+                f"does not match pattern ({field['constraints']['pattern']})")
+        description += f' Example: `{field["example"]}`.'
     return description.strip()
 
 

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -43,17 +43,7 @@ def _enrich_description(field):
 
 def generate_readme_md(
         table_schema, directory_schemas, type, is_top_level=False):
-    fields_md_list = []
-    for field in table_schema['fields']:
-        if 'heading' in field:
-            fields_md_list.append(f"## {field['heading']}")
-        table_md = _make_constraints_table(field)
-        fields_md_list.append(f"""### `{field['name']}`
-{_enrich_description(field)}
-
-{table_md}""")
-
-    fields_md = '\n\n'.join(fields_md_list)
+    fields_md = _make_fields_md(table_schema)
     toc_md = _make_toc(fields_md)
     dir_description_md = _make_dir_description(directory_schemas)
 
@@ -86,6 +76,19 @@ Related files:
 {optional_dir_description_md}
 {fields_md}
 '''
+
+
+def _make_fields_md(table_schema):
+    fields_md_list = []
+    for field in table_schema['fields']:
+        if 'heading' in field:
+            fields_md_list.append(f"## {field['heading']}")
+        table_md = _make_constraints_table(field)
+        fields_md_list.append(f"""### `{field['name']}`
+{_enrich_description(field)}
+
+{table_md}""")
+    return '\n\n'.join(fields_md_list)
 
 
 def _make_constraints_table(field):

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -25,20 +25,24 @@ def _enrich_description(field):
     '''
     >>> field = {
     ...   'description': 'something',
-    ...   'constraints': {'required': False}
+    ...   'constraints': {'required': False, 'pattern': r'\\[A-Z]+\\d+'},
+    ...   'example': 'ABC123'
     ... }
     >>> _enrich_description(field)
-    'something. Leave blank if not applicable.'
+    'something. Leave blank if not applicable. example: `ABC123`.'
 
     '''
+    # Some descriptions end with periods; some don't.
+    description = re.sub(r'\.\s*$', '. ', field['description'])
     if (
         'constraints' in field
         and 'required' in field['constraints']
         and not field['constraints']['required']
     ):
-        stripped = re.sub(r'\W+\s*$', '', field['description'])
-        return stripped + '. Leave blank if not applicable.'
-    return field['description']
+        description += 'Leave blank if not applicable. '
+    if 'example' in field:
+        description += f'Example: `{field["example"]}`. '
+    return description.strip()
 
 
 def generate_readme_md(

--- a/src/ingest_validation_tools/table-schemas/level-1.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-1.yaml
@@ -5,11 +5,13 @@ fields:
     description: HuBMAP Display ID of the donor of the assayed tissue.
     constraints:
       pattern: '[A-Z]+[0-9]+'
+    example: 'ABC123'
   -
     name: tissue_id
     description: HuBMAP Display ID of the assayed tissue.
     constraints:
       pattern: '([A-Z]+[0-9]+)-(BL|BR|LB|RB|HT|LK|RK|LI|LV|LL|RL|LY\d\d|SI|SP|TH|TR|UR|OT)(-\d+)+(_\d+)?'
+    example: 'ABC123-BL-1-2-3_456'
   -
     heading: Level 1
     name: execution_datetime


### PR DESCRIPTION
- Add examples for two pattern validated fields in yaml.
- Regenerate docs to include these examples.
- Add code that will error if the example isn't actually good.
- Add periods at ends of descriptions... not strictly necessary, but it makes the machinery for adding these extra phrases more clear.

Fix #356