### PR TITLE
Add mypy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.0.6 - In progress
 - Add thumbnail to directory schema.
 - Add machinery to include regex examples in docs.
+- Run mypy on the one file that has type annotations.
 
 ## v0.0.5 - 2020-11-09
 - Change "mixif" to "mxif".

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+files = src/ingest_validation_tools/plugin_validator.py
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8==3.7.9
 pytest==5.4.1
 autopep8==1.5
+mypy==0.790

--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -1,5 +1,5 @@
 import sys
-import importlib
+from importlib import util
 import inspect
 from typing import List, Union, Tuple, Iterator
 from pathlib import Path
@@ -116,10 +116,10 @@ def validation_error_iter(base_dir: PathOrStr, assay_type: str,
         if mod_nm in sys.modules:
             mod = sys.modules[mod_nm]
         else:
-            spec = importlib.util.spec_from_file_location(mod_nm, fpath)
-            mod = importlib.util.module_from_spec(spec)
+            spec = util.spec_from_file_location(mod_nm, fpath)
+            mod = util.module_from_spec(spec)
             sys.modules[mod_nm] = mod
-            spec.loader.exec_module(mod)
+            spec.loader.exec_module(mod)  # type: ignore
         for name, obj in inspect.getmembers(mod):
             if inspect.isclass(obj) and obj != Validator and issubclass(obj, Validator):
                 sort_me.append((obj.cost, obj.description, obj))

--- a/test.sh
+++ b/test.sh
@@ -13,6 +13,10 @@ start flake8
 flake8 || die 'Try: autopep8 --in-place --aggressive -r .'
 end flake8
 
+start mypy
+mypy
+end mypy
+
 for TEST in test-*; do
   start $TEST
   eval ./$TEST


### PR DESCRIPTION
There are other type checking tools, and there are a lot of options just in `mypy`, so I'm not sure if this is the best way to get started, but I think where we have annotations, they should be checked. 

I changed the imports to silence one error:
```
src/ingest_validation_tools/plugin_validator.py:119: error: Module has no attribute "util"
src/ingest_validation_tools/plugin_validator.py:120: error: Module has no attribute "util"
```
... but without the `type: ignore` it would now fail with:
```
src/ingest_validation_tools/plugin_validator.py:122: error: Item "_Loader" of "Optional[_Loader]" has no attribute "exec_module"
src/ingest_validation_tools/plugin_validator.py:122: error: Item "None" of "Optional[_Loader]" has no attribute "exec_module"
```

If I were planning to use type checking more, I would need to understand what this really means... but I'm not planning to invest time there, so an ignore seems ok?