### PR TITLE
Online ID validation / Check character encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.0.8 - in progress
 - Allow "X" as final character of ORCID.
-- Check that ORCIDs are good.
+- Ping the respective services to confirm the ORCIDs, RR IDs, and Uniprot IDs are actually good.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.0.8 - in progress
 - Allow "X" as final character of ORCID.
+- Check that ORCIDs are good.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.8 - in progress
+- Allow "X" as final character of ORCID.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.0.8 - in progress
 - Allow "X" as final character of ORCID.
 - Ping the respective services to confirm the ORCIDs, RR IDs, and Uniprot IDs are actually good.
+- Add encoding as CLI param.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/README-validate_submission.py.md
+++ b/README-validate_submission.py.md
@@ -4,6 +4,7 @@ usage: validate_submission.py [-h] [--local_directory PATH]
                               [--optional_fields FIELD [FIELD ...]]
                               [--dataset_ignore_globs GLOB [GLOB ...]]
                               [--submission_ignore_globs GLOB [GLOB ...]]
+                              [--encoding ENCODING]
                               [--plugin_directory PLUGIN_DIRECTORY]
                               [--output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}]
                               [--add_notes]
@@ -22,10 +23,14 @@ optional arguments:
                         they are supplied in the TSV, they will be validated.)
   --dataset_ignore_globs GLOB [GLOB ...]
                         Matching files in each dataset directory will be
-                        ignored.
+                        ignored. Default: .*
   --submission_ignore_globs GLOB [GLOB ...]
                         Matching sub-directories in the submission will be
                         ignored.
+  --encoding ENCODING   Character-encoding to use for parsing TSVs. Default:
+                        ascii. Work-in-progress:
+                        https://github.com/hubmapconsortium/ingest-validation-
+                        tools/issues/494
   --plugin_directory PLUGIN_DIRECTORY
                         Directory of plugin tests.
   --output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}

--- a/dataset-examples/bad-codex-data/README.md
+++ b/dataset-examples/bad-codex-data/README.md
@@ -33,4 +33,6 @@ Metadata TSV Errors:
         - Column 5 ("E") is a required field, but row 2 has no value
         - The value "invalid" in row 2 and column 6 ("F") does not conform to the
           pattern constraint of "1/\d+"
+        External:
+          row 2, rr_id bad-value: 404
 ```

--- a/dataset-examples/bad-codex-data/README.md
+++ b/dataset-examples/bad-codex-data/README.md
@@ -21,7 +21,7 @@ Metadata TSV Errors:
         - src_[^/]+/channelnames_report\.csv
       row 2, contributors dataset-examples/bad-codex-data/submission/contributors.tsv:
       - The value "bad-id" in row 2 and column 6 ("F") does not conform to the pattern
-        constraint of "\d{4}-\d{4}-\d{4}-\d{4}"
+        constraint of "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
       row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv:
       - Column 1 ("A") is a required field, but row 2 has no value
       - Column 2 ("B") is a required field, but row 2 has no value

--- a/dataset-examples/bad-codex-data/README.md
+++ b/dataset-examples/bad-codex-data/README.md
@@ -20,15 +20,17 @@ Metadata TSV Errors:
         - src_[^/]+/channelnames\.txt
         - src_[^/]+/channelnames_report\.csv
       row 2, contributors dataset-examples/bad-codex-data/submission/contributors.tsv:
-      - The value "bad-id" in row 2 and column 6 ("F") does not conform to the pattern
-        constraint of "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
+        Internal:
+        - The value "bad-id" in row 2 and column 6 ("F") does not conform to the pattern
+          constraint of "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
       row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv:
-      - Column 1 ("A") is a required field, but row 2 has no value
-      - Column 2 ("B") is a required field, but row 2 has no value
-      - The value "bad-value" in row 2 and column 3 ("C") does not conform to the
-        pattern constraint of "AB_\d+"
-      - Column 4 ("D") is a required field, but row 2 has no value
-      - Column 5 ("E") is a required field, but row 2 has no value
-      - The value "invalid" in row 2 and column 6 ("F") does not conform to the pattern
-        constraint of "1/\d+"
+        Internal:
+        - Column 1 ("A") is a required field, but row 2 has no value
+        - Column 2 ("B") is a required field, but row 2 has no value
+        - The value "bad-value" in row 2 and column 3 ("C") does not conform to the
+          pattern constraint of "AB_\d+"
+        - Column 4 ("D") is a required field, but row 2 has no value
+        - Column 5 ("E") is a required field, but row 2 has no value
+        - The value "invalid" in row 2 and column 6 ("F") does not conform to the
+          pattern constraint of "1/\d+"
 ```

--- a/dataset-examples/bad-codex-data/README.md
+++ b/dataset-examples/bad-codex-data/README.md
@@ -23,16 +23,6 @@ Metadata TSV Errors:
         Internal:
         - The value "bad-id" in row 2 and column 6 ("F") does not conform to the pattern
           constraint of "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
-      row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv:
-        Internal:
-        - Column 1 ("A") is a required field, but row 2 has no value
-        - Column 2 ("B") is a required field, but row 2 has no value
-        - The value "bad-value" in row 2 and column 3 ("C") does not conform to the
-          pattern constraint of "AB_\d+"
-        - Column 4 ("D") is a required field, but row 2 has no value
-        - Column 5 ("E") is a required field, but row 2 has no value
-        - The value "invalid" in row 2 and column 6 ("F") does not conform to the
-          pattern constraint of "1/\d+"
-        External:
-          row 2, rr_id bad-value: 404
+      row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv: '''ascii''
+        codec can''t decode byte 0xf0 in position 113: ordinal not in range(128)'
 ```

--- a/dataset-examples/bad-codex-data/submission/antibodies.tsv
+++ b/dataset-examples/bad-codex-data/submission/antibodies.tsv
@@ -1,2 +1,2 @@
 channel_id	antibody_name	rr_id	uniprot_accession_number	lot_number	dilution	conjugated_cat_number	conjugated_tag
-		bad-value			invalid		
+😃		bad-value			invalid		

--- a/dataset-examples/bad-missing-data/README.md
+++ b/dataset-examples/bad-missing-data/README.md
@@ -5,7 +5,9 @@ Metadata TSV Errors:
       row 2, referencing dataset-examples/bad-missing-data/submission/dataset-1:
         No such file or directory: dataset-examples/bad-missing-data/submission/dataset-1
       row 2, contributors dataset-examples/bad-missing-data/submission/contributors-missing.tsv:
-      - 'No such file or directory: ''dataset-examples/bad-missing-data/submission/contributors-missing.tsv'''
+        Internal:
+        - 'No such file or directory: ''dataset-examples/bad-missing-data/submission/contributors-missing.tsv'''
       row 2, antibodies dataset-examples/bad-missing-data/submission/antibodies-missing.tsv:
-      - 'No such file or directory: ''dataset-examples/bad-missing-data/submission/antibodies-missing.tsv'''
+        Internal:
+        - 'No such file or directory: ''dataset-examples/bad-missing-data/submission/antibodies-missing.tsv'''
 ```

--- a/dataset-examples/bad-missing-data/README.md
+++ b/dataset-examples/bad-missing-data/README.md
@@ -6,7 +6,6 @@ Metadata TSV Errors:
         No such file or directory: dataset-examples/bad-missing-data/submission/dataset-1
       row 2, contributors dataset-examples/bad-missing-data/submission/contributors-missing.tsv: File
         does not exist
-      row 2, antibodies dataset-examples/bad-missing-data/submission/antibodies-missing.tsv:
-        Internal:
-        - 'No such file or directory: ''dataset-examples/bad-missing-data/submission/antibodies-missing.tsv'''
+      row 2, antibodies dataset-examples/bad-missing-data/submission/antibodies-missing.tsv: File
+        does not exist
 ```

--- a/dataset-examples/bad-missing-data/README.md
+++ b/dataset-examples/bad-missing-data/README.md
@@ -4,9 +4,8 @@ Metadata TSV Errors:
     External:
       row 2, referencing dataset-examples/bad-missing-data/submission/dataset-1:
         No such file or directory: dataset-examples/bad-missing-data/submission/dataset-1
-      row 2, contributors dataset-examples/bad-missing-data/submission/contributors-missing.tsv:
-        Internal:
-        - 'No such file or directory: ''dataset-examples/bad-missing-data/submission/contributors-missing.tsv'''
+      row 2, contributors dataset-examples/bad-missing-data/submission/contributors-missing.tsv: File
+        does not exist
       row 2, antibodies dataset-examples/bad-missing-data/submission/antibodies-missing.tsv:
         Internal:
         - 'No such file or directory: ''dataset-examples/bad-missing-data/submission/antibodies-missing.tsv'''

--- a/dataset-examples/bad-mixed/README.md
+++ b/dataset-examples/bad-mixed/README.md
@@ -20,9 +20,8 @@ Metadata TSV Errors:
         - src_[^/]+/channelnames_report\.csv
       row 2, contributors dataset-examples/bad-mixed/submission/contributors.tsv: File
         has no data rows.
-      row 2, antibodies dataset-examples/bad-mixed/submission/antibodies.tsv:
-        Internal:
-        - 'No such file or directory: ''dataset-examples/bad-mixed/submission/antibodies.tsv'''
+      row 2, antibodies dataset-examples/bad-mixed/submission/antibodies.tsv: File
+        does not exist
   dataset-examples/bad-mixed/submission/scatacseq-metadata.tsv (as scatacseq):
     Internal:
     - The value "-INVALID-" in row 2 and column 1 ("A") does not conform to the pattern

--- a/dataset-examples/bad-mixed/README.md
+++ b/dataset-examples/bad-mixed/README.md
@@ -18,6 +18,8 @@ Metadata TSV Errors:
         - drv_[^/]+/segmentation\.json
         - src_[^/]+/channelnames\.txt
         - src_[^/]+/channelnames_report\.csv
+      row 2, contributors dataset-examples/bad-mixed/submission/contributors.tsv: File
+        has no data rows.
       row 2, antibodies dataset-examples/bad-mixed/submission/antibodies.tsv:
         Internal:
         - 'No such file or directory: ''dataset-examples/bad-mixed/submission/antibodies.tsv'''
@@ -33,6 +35,8 @@ Metadata TSV Errors:
         - not-good-for-either-type.txt
         Required but missing:
         - .*\.fastq\.gz
+      row 2, contributors dataset-examples/bad-mixed/submission/contributors.tsv: File
+        has no data rows.
       row 2, protocols_io_doi 10.17504/fake: 404
 Reference Errors:
   Multiple References:

--- a/dataset-examples/bad-mixed/README.md
+++ b/dataset-examples/bad-mixed/README.md
@@ -19,7 +19,8 @@ Metadata TSV Errors:
         - src_[^/]+/channelnames\.txt
         - src_[^/]+/channelnames_report\.csv
       row 2, antibodies dataset-examples/bad-mixed/submission/antibodies.tsv:
-      - 'No such file or directory: ''dataset-examples/bad-mixed/submission/antibodies.tsv'''
+        Internal:
+        - 'No such file or directory: ''dataset-examples/bad-mixed/submission/antibodies.tsv'''
   dataset-examples/bad-mixed/submission/scatacseq-metadata.tsv (as scatacseq):
     Internal:
     - The value "-INVALID-" in row 2 and column 1 ("A") does not conform to the pattern

--- a/dataset-examples/bad-scatacseq-data/README.md
+++ b/dataset-examples/bad-scatacseq-data/README.md
@@ -11,7 +11,8 @@ Metadata TSV Errors:
         - unexpected-directory/place-holder.txt
         Required but missing:
         - .*\.fastq\.gz
-      row 2, contributors dataset-examples/bad-scatacseq-data/submission/contributors.tsv: File
-        has no data rows.
+      row 2, contributors dataset-examples/bad-scatacseq-data/submission/contributors.tsv:
+        External:
+          row 2, orcid_id 0000-0000-0000-000X: 404
       row 2, protocols_io_doi 10.17504/fake: 404
 ```

--- a/dataset-examples/bad-scatacseq-data/README.md
+++ b/dataset-examples/bad-scatacseq-data/README.md
@@ -11,5 +11,7 @@ Metadata TSV Errors:
         - unexpected-directory/place-holder.txt
         Required but missing:
         - .*\.fastq\.gz
+      row 2, contributors dataset-examples/bad-scatacseq-data/submission/contributors.tsv: File
+        has no data rows.
       row 2, protocols_io_doi 10.17504/fake: 404
 ```

--- a/dataset-examples/bad-scatacseq-data/submission/contributors.tsv
+++ b/dataset-examples/bad-scatacseq-data/submission/contributors.tsv
@@ -1,1 +1,2 @@
 affiliation	first_name	last_name	middle_name_or_initial	name	orcid_id
+Some Institution	John	Smith	X	John X. Smith	0000-0000-0000-000X

--- a/dataset-examples/bad-tsv-formats/README.md
+++ b/dataset-examples/bad-tsv-formats/README.md
@@ -67,7 +67,8 @@ Metadata TSV Errors:
         - src_[^/]+/channelnames\.txt
         - src_[^/]+/channelnames_report\.csv
       row 2, antibodies dataset-examples/bad-tsv-formats/submission/antibodies.tsv:
-      - 'No such file or directory: ''dataset-examples/bad-tsv-formats/submission/antibodies.tsv'''
+        Internal:
+        - 'No such file or directory: ''dataset-examples/bad-tsv-formats/submission/antibodies.tsv'''
       row 2, protocols_io_doi 10\.17504/protocols.io.menc3de: 404
       row 2, section_prep_protocols_io_doi not-doi: 404
       row 2, reagent_prep_protocols_io_doi not-doi: 404

--- a/dataset-examples/bad-tsv-formats/README.md
+++ b/dataset-examples/bad-tsv-formats/README.md
@@ -66,6 +66,8 @@ Metadata TSV Errors:
         - drv_[^/]+/segmentation\.json
         - src_[^/]+/channelnames\.txt
         - src_[^/]+/channelnames_report\.csv
+      row 2, contributors dataset-examples/bad-tsv-formats/submission/contributors.tsv: File
+        has no data rows.
       row 2, antibodies dataset-examples/bad-tsv-formats/submission/antibodies.tsv:
         Internal:
         - 'No such file or directory: ''dataset-examples/bad-tsv-formats/submission/antibodies.tsv'''

--- a/dataset-examples/bad-tsv-formats/README.md
+++ b/dataset-examples/bad-tsv-formats/README.md
@@ -68,9 +68,8 @@ Metadata TSV Errors:
         - src_[^/]+/channelnames_report\.csv
       row 2, contributors dataset-examples/bad-tsv-formats/submission/contributors.tsv: File
         has no data rows.
-      row 2, antibodies dataset-examples/bad-tsv-formats/submission/antibodies.tsv:
-        Internal:
-        - 'No such file or directory: ''dataset-examples/bad-tsv-formats/submission/antibodies.tsv'''
+      row 2, antibodies dataset-examples/bad-tsv-formats/submission/antibodies.tsv: File
+        does not exist
       row 2, protocols_io_doi 10\.17504/protocols.io.menc3de: 404
       row 2, section_prep_protocols_io_doi not-doi: 404
       row 2, reagent_prep_protocols_io_doi not-doi: 404

--- a/dataset-examples/good-codex-akoya/submission/antibodies.tsv
+++ b/dataset-examples/good-codex-akoya/submission/antibodies.tsv
@@ -1,2 +1,2 @@
 channel_id	antibody_name	rr_id	uniprot_accession_number	lot_number	dilution	conjugated_cat_number	conjugated_tag
-channel-depends-on-assay	whatever	AB_123	whatever	whatever	1/100		whatever
+channel-depends-on-assay	whatever	AB_1934296	G9N9I7	whatever	1/100		whatever

--- a/dataset-examples/good-codex-akoya/submission/contributors.tsv
+++ b/dataset-examples/good-codex-akoya/submission/contributors.tsv
@@ -1,2 +1,2 @@
 affiliation	first_name	last_name	middle_name_or_initial	name	orcid_id
-Some Institution	John	Smith	X	John X. Smith	1234-1234-1234-1234
+Some Institution	John	Smith	X	John X. Smith	0000-0003-4039-9768

--- a/dataset-examples/good-scatacseq/submission/contributors.tsv
+++ b/dataset-examples/good-scatacseq/submission/contributors.tsv
@@ -1,2 +1,2 @@
 affiliation	first_name	last_name	middle_name_or_initial	name	orcid_id
-Some Institution	John	Smith	X	John X. Smith	1234-1234-1234-1234
+Some Institution	John	Smith	X	John X. Smith	0000-0003-4039-9768

--- a/dataset-iec-examples/bad-example/README.md
+++ b/dataset-iec-examples/bad-example/README.md
@@ -1,6 +1,6 @@
 In metadata.tsv, the value "bad-donor-id" in row 2 and column 1 ("A") is not the right form.
-In the dataset referenced by row 2, referencing dataset-iec-examples/bad-example/submission, the file "should-not-be-here.txt" is not allowed.
-In metadata.tsv (as scatacseq): External: row 2, contributors dataset-iec-examples/bad-example/submission/extras/contributors.tsv: The value "bad-orcid" in row 2 and column 6 ("F") is not the right form.
+In the dataset dataset-iec-examples/bad-example/submission referenced on row 2, the file "should-not-be-here.txt" is not allowed.
+In the contributors dataset-iec-examples/bad-example/submission/extras/contributors.tsv referenced on row 2, the value "bad-orcid" in row 2 and column 6 ("F") is not the right form.
 In metadata.tsv (as scatacseq): External: row 2, protocols_io_doi 10.17504/fake: 404.
 In metadata.tsv (as scatacseq): External: row 2, sc_isolation_protocols_io_doi 10.17504/fake: 404.
 In metadata.tsv (as scatacseq): External: row 2, library_construction_protocols_io_doi 10.17504/fake: 404.

--- a/dataset-iec-examples/good-example/submission/extras/contributors.tsv
+++ b/dataset-iec-examples/good-example/submission/extras/contributors.tsv
@@ -1,2 +1,2 @@
 affiliation	first_name	last_name	middle_name_or_initial	name	orcid_id
-Some Institution	John	Smith	X	John X. Smith	1234-1234-1234-1234
+Some Institution	John	Smith	X	John X. Smith	0000-0003-4039-9768

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -54,5 +54,5 @@ ORCID ID of contributor.
 
 | constraint | value |
 | --- | --- |
-| pattern (regular expression) | `\d{4}-\d{4}-\d{4}-\d{4}` |
+| pattern (regular expression) | `\d{4}-\d{4}-\d{4}-\d{3}[0-9X]` |
 | required | `True` |

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -50,7 +50,7 @@ Name for display.
 | required | `True` |
 
 ### `orcid_id`
-ORCID ID of contributor.
+ORCID ID of contributor. Example: `0000-0002-8928-741X`.
 
 | constraint | value |
 | --- | --- |

--- a/src/ingest_validation_tools/message_munger.py
+++ b/src/ingest_validation_tools/message_munger.py
@@ -26,8 +26,8 @@ def munge(message):
         (r'.*: External: (row \d+), referencing ([^:]+): ([^:]+): (.+)',
          r'In the dataset \2 referenced on \1, the file "\4" is \3.'),
 
-        (r'.*: External: (row \d+), contributors ([^:]+): ([^:]+): (.+)',
-         r'In the contributors \2 referenced on \1, \4'),
+        (r'.*: External: (row \d+), ([^:]+): ([^:]+): (.+)',
+         r'In the \2 referenced on \1, \4'),
 
         (r' \(as \S+\): External: Warning: File has no data rows',
          r', the file is just a header with no data rows'),

--- a/src/ingest_validation_tools/message_munger.py
+++ b/src/ingest_validation_tools/message_munger.py
@@ -4,6 +4,10 @@ from re import sub
 def munge(message):
     '''
     Make the error message less informative.
+
+    >>> munge("In md.tsv (as fake): External: row 2, referencing fake/ds: Not allowed: nope.txt")
+    'In the dataset referenced by row 2, referencing fake/ds, the file "nope.txt" is not allowed.'
+
     '''
     pat_reps = [
         (r'does not conform to the pattern constraint of .*',

--- a/src/ingest_validation_tools/message_munger.py
+++ b/src/ingest_validation_tools/message_munger.py
@@ -5,8 +5,12 @@ def munge(message):
     '''
     Make the error message less informative.
 
-    >>> munge("In md.tsv (as fake): External: row 2, referencing fake/ds: Not allowed: nope.txt")
-    'In the dataset referenced by row 2, referencing fake/ds, the file "nope.txt" is not allowed.'
+    >>> munge('In md.tsv (as fake): External: row 2, referencing fake/ds: Not allowed: nope.txt')
+    'In the dataset fake/ds referenced on row 2, the file "nope.txt" is not allowed.'
+
+    >>> munge('In md.tsv (as fake): External: row 2, contributors c.tsv: '
+    ...       'Internal: Blah blah.')
+    'In the contributors c.tsv referenced on row 2, blah blah.'
 
     '''
     pat_reps = [
@@ -19,8 +23,11 @@ def munge(message):
         (r' \(as \S+\): Internal:',
          ','),
 
-        (r'.*: External: ([^:]+): ([^:]+): (.+)',
-         r'In the dataset referenced by \1, the file "\3" is \2.'),
+        (r'.*: External: (row \d+), referencing ([^:]+): ([^:]+): (.+)',
+         r'In the dataset \2 referenced on \1, the file "\4" is \3.'),
+
+        (r'.*: External: (row \d+), contributors ([^:]+): ([^:]+): (.+)',
+         r'In the contributors \2 referenced on \1, \4'),
 
         (r' \(as \S+\): External: Warning: File has no data rows',
          r', the file is just a header with no data rows'),

--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -63,7 +63,9 @@ def run_plugin_validators_iter(metadata_path: PathOrStr,
     metadata_path = Path(metadata_path)
     if metadata_path.is_file():
         try:
-            rows = dict_reader_wrapper(metadata_path)
+            rows = dict_reader_wrapper(metadata_path, 'ascii')
+            # TODO: Pass in encoding.
+            # https://github.com/hubmapconsortium/ingest-validation-tools/issues/494
         except (CsvError, IOError):
             raise ValidatorError(f'{metadata_path} could not be parsed as a .tsv file')
         if not rows:

--- a/src/ingest_validation_tools/submission.py
+++ b/src/ingest_validation_tools/submission.py
@@ -142,7 +142,10 @@ class Submission:
             optional_fields=self.optional_fields)
 
     def _get_single_tsv_external_errors(self, assay_type, path):
-        rows = dict_reader_wrapper(path, self.encoding)
+        try:
+            rows = dict_reader_wrapper(path, self.encoding)
+        except UnicodeDecodeError as e:
+            return str(e)
         if not rows:
             return 'File has no data rows.'
         if 'data_path' not in rows[0] or 'contributors_path' not in rows[0]:

--- a/src/ingest_validation_tools/submission.py
+++ b/src/ingest_validation_tools/submission.py
@@ -34,14 +34,6 @@ def _assay_name_to_code(name):
     return None
 
 
-def _get_type_from_first_line(path):
-    rows = dict_reader_wrapper(path)
-    if not rows:
-        return None
-    name = rows[0]['assay_type']
-    return _assay_name_to_code(name)
-
-
 TSV_SUFFIX = 'metadata.tsv'
 
 
@@ -49,14 +41,15 @@ class Submission:
     def __init__(self, directory_path=None, tsv_paths=[],
                  optional_fields=[], add_notes=True,
                  dataset_ignore_globs=[], submission_ignore_globs=[],
-                 plugin_directory=None):
+                 plugin_directory=None, encoding=None):
         self.directory_path = directory_path
         self.optional_fields = optional_fields
         self.dataset_ignore_globs = dataset_ignore_globs
         self.submission_ignore_globs = submission_ignore_globs
         self.plugin_directory = plugin_directory
+        self.encoding = encoding
         unsorted_effective_tsv_paths = {
-            str(path): _get_type_from_first_line(path)
+            str(path): self._get_type_from_first_line(path)
             for path in (
                 tsv_paths if tsv_paths
                 else directory_path.glob(f'*{TSV_SUFFIX}')
@@ -67,6 +60,13 @@ class Submission:
             for k in sorted(unsorted_effective_tsv_paths.keys())
         }
         self.add_notes = add_notes
+
+    def _get_type_from_first_line(self, path):
+        rows = dict_reader_wrapper(path, self.encoding)
+        if not rows:
+            return None
+        name = rows[0]['assay_type']
+        return _assay_name_to_code(name)
 
     def get_errors(self):
         # This creates a deeply nested dict.
@@ -142,7 +142,7 @@ class Submission:
             optional_fields=self.optional_fields)
 
     def _get_single_tsv_external_errors(self, assay_type, path):
-        rows = dict_reader_wrapper(path)
+        rows = dict_reader_wrapper(path, self.encoding)
         if not rows:
             return 'File has no data rows.'
         if 'data_path' not in rows[0] or 'contributors_path' not in rows[0]:
@@ -196,10 +196,10 @@ class Submission:
             assay_type, data_path, dataset_ignore_globs=self.dataset_ignore_globs)
 
     def _get_contributors_errors(self, contributors_path):
-        return get_contributors_errors(contributors_path)
+        return get_contributors_errors(contributors_path, self.encoding)
 
     def _get_antibodies_errors(self, antibodies_path):
-        return get_antibodies_errors(antibodies_path)
+        return get_antibodies_errors(antibodies_path, self.encoding)
 
     def _get_reference_errors(self):
         errors = {}
@@ -248,7 +248,7 @@ class Submission:
     def _get_references(self, col_name):
         references = defaultdict(list)
         for tsv_path in self.effective_tsv_paths.keys():
-            for i, row in enumerate(dict_reader_wrapper(tsv_path)):
+            for i, row in enumerate(dict_reader_wrapper(tsv_path, self.encoding)):
                 if col_name in row:
                     reference = f'{tsv_path} (row {i+2})'
                     references[row[col_name]].append(reference)

--- a/src/ingest_validation_tools/table-schemas/contributors.yaml
+++ b/src/ingest_validation_tools/table-schemas/contributors.yaml
@@ -18,4 +18,5 @@ fields:
     name: orcid_id
     description: ORCID ID of contributor
     constraints:
-      pattern: '\d{4}-\d{4}-\d{4}-\d{4}'
+      pattern: '\d{4}-\d{4}-\d{4}-\d{3}[0-9X]'
+    example: 0000-0002-8928-741X

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -41,14 +41,24 @@ def get_contributors_errors(contributors_path):
     '''
     Validate a single contributors file.
     '''
-    return get_tsv_errors(contributors_path, 'contributors')
+    errors = {}
+    internal_errors = get_tsv_errors(contributors_path, 'contributors')
+    if internal_errors:
+        errors['Contributors internal'] = internal_errors
+    # TODO: External
+    return internal_errors
 
 
 def get_antibodies_errors(antibodies_path):
     '''
     Validate a single antibodies file.
     '''
-    return get_tsv_errors(antibodies_path, 'antibodies')
+    errors = {}
+    internal_errors = get_tsv_errors(antibodies_path, 'antibodies')
+    if internal_errors:
+        errors['Antibodies internal'] = internal_errors
+    # TODO: External
+    return internal_errors
 
 
 def get_tsv_errors(tsv_path, type, optional_fields=[]):

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -44,9 +44,9 @@ def get_contributors_errors(contributors_path):
     errors = {}
     internal_errors = get_tsv_errors(contributors_path, 'contributors')
     if internal_errors:
-        errors['Contributors internal'] = internal_errors
+        errors['Internal'] = internal_errors
     # TODO: External
-    return internal_errors
+    return errors
 
 
 def get_antibodies_errors(antibodies_path):
@@ -56,9 +56,9 @@ def get_antibodies_errors(antibodies_path):
     errors = {}
     internal_errors = get_tsv_errors(antibodies_path, 'antibodies')
     if internal_errors:
-        errors['Antibodies internal'] = internal_errors
+        errors['Internal'] = internal_errors
     # TODO: External
-    return internal_errors
+    return errors
 
 
 def get_tsv_errors(tsv_path, type, optional_fields=[]):

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -48,6 +48,10 @@ status_of_id: dict = {
 def _get_in_ex_errors(path, type_name, field_url_tuples, encoding):
     if not path.exists():
         return 'File does not exist'
+    try:
+        rows = dict_reader_wrapper(path, encoding)
+    except UnicodeDecodeError as e:
+        return str(e)
     rows = dict_reader_wrapper(path, encoding)
     if not rows:
         return 'File has no data rows.'

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -18,8 +18,8 @@ class TableValidationErrors(Exception):
     pass
 
 
-def dict_reader_wrapper(path):
-    with open(path, encoding='latin-1') as f:
+def dict_reader_wrapper(path, encoding):
+    with open(path, encoding=encoding) as f:
         rows = list(DictReader(f, dialect='excel-tab'))
     return rows
 
@@ -45,10 +45,10 @@ status_of_id: dict = {
 }
 
 
-def _get_in_ex_errors(path, type_name, field_url_tuples):
+def _get_in_ex_errors(path, type_name, field_url_tuples, encoding):
     if not path.exists():
         return 'File does not exist'
-    rows = dict_reader_wrapper(path)
+    rows = dict_reader_wrapper(path, encoding)
     if not rows:
         return 'File has no data rows.'
 
@@ -81,18 +81,19 @@ def _get_in_ex_errors(path, type_name, field_url_tuples):
     return errors
 
 
-def get_contributors_errors(contributors_path):
+def get_contributors_errors(contributors_path, encoding):
     '''
     Validate a single contributors file.
     '''
     return _get_in_ex_errors(
         contributors_path, 'contributors', [
             ('orcid_id', 'https://orcid.org/', None)
-        ]
+        ],
+        encoding
     )
 
 
-def get_antibodies_errors(antibodies_path):
+def get_antibodies_errors(antibodies_path, encoding):
     '''
     Validate a single antibodies file.
     '''
@@ -102,7 +103,8 @@ def get_antibodies_errors(antibodies_path):
             ('rr_id', 'https://antibodyregistry.org/search.php?q=',
                 'Showing 1 - 1 results out of 1'),
             ('uniprot_accession_number', 'https://www.uniprot.org/uniprot/', None)
-        ]
+        ],
+        encoding
     )
 
 

--- a/src/validate_submission.py
+++ b/src/validate_submission.py
@@ -59,16 +59,24 @@ Typical usecases:
         '(But if they are supplied in the TSV, they will be validated.)'
     )
 
+    default_ignore = '.*'
     parser.add_argument(
         '--dataset_ignore_globs', nargs='+',
         metavar='GLOB',
-        default=['.*'],
-        help='Matching files in each dataset directory will be ignored.'
+        default=[default_ignore],
+        help=f'Matching files in each dataset directory will be ignored. Default: {default_ignore}'
     )
     parser.add_argument(
         '--submission_ignore_globs', nargs='+',
         metavar='GLOB',
         help='Matching sub-directories in the submission will be ignored.'
+    )
+
+    default_encoding = 'ascii'
+    parser.add_argument(
+        '--encoding', default=default_encoding,
+        help=f'Character-encoding to use for parsing TSVs. Default: {default_encoding}. '
+        'Work-in-progress: https://github.com/hubmapconsortium/ingest-validation-tools/issues/494'
     )
 
     # Are there plugin validations?
@@ -110,6 +118,7 @@ def main():
     args = parse_args()
     submission_args = {
         'add_notes': args.add_notes,
+        'encoding': args.encoding,
         'optional_fields': args.optional_fields or []
     }
 


### PR DESCRIPTION
Fix #489, fix #490, fix #491.

One thing to confirm: Is hitting 
```
https://orcid.org/...
https://antibodyregistry.org/search.php?q=...
https://www.uniprot.org/uniprot/...
```
the right way to confirm that the corresponding IDs exist, or would you prefer something else?