### PR TITLE
Let an example be supplied to supplement regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add encoding as CLI param.
 - Add `--offline` option, and use it internally.
 - Fix the CLI parameter parsing: Either `--local_directory` or `--tsv_paths` must be provided.
+- Allow examples of path rexes to be provided.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/docs/af/README.md
+++ b/docs/af/README.md
@@ -44,7 +44,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `processedMicroscopy/[^/]+_preMxIF_images/[^/]+\.ome\.tif` | ✓ | OME TIFF files (multichannel, multi-layered, image pyramids) produced by the autofluorescence microscopy linked to MxIF experiment |
 | `processedMicroscopy/[^/]+_preMxIF_transformations/[^/]+\.txt` | ✓ | Transformations to MxIF (related) data |

--- a/docs/af/README.md
+++ b/docs/af/README.md
@@ -44,7 +44,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `processedMicroscopy/[^/]+_preMxIF_images/[^/]+\.ome\.tif` | ✓ | OME TIFF files (multichannel, multi-layered, image pyramids) produced by the autofluorescence microscopy linked to MxIF experiment |
 | `processedMicroscopy/[^/]+_preMxIF_transformations/[^/]+\.txt` | ✓ | Transformations to MxIF (related) data |

--- a/docs/bulkatacseq/README.md
+++ b/docs/bulkatacseq/README.md
@@ -59,7 +59,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `.*\.fastq\.gz` | ✓ | TODO: https://github.com/hubmapconsortium/ingest-validation-tools/issues/445 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/bulkatacseq/README.md
+++ b/docs/bulkatacseq/README.md
@@ -59,7 +59,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `.*\.fastq\.gz` | ✓ | TODO: https://github.com/hubmapconsortium/ingest-validation-tools/issues/445 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/bulkrnaseq/README.md
+++ b/docs/bulkrnaseq/README.md
@@ -54,7 +54,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/446 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/bulkrnaseq/README.md
+++ b/docs/bulkrnaseq/README.md
@@ -54,7 +54,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/446 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/celldive/README.md
+++ b/docs/celldive/README.md
@@ -47,7 +47,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `channel_list\.txt` | ✓ | Information about the capture channels and tags (comma separated) |
 | `slide_list\.txt` | ✓ | Information about the slides used by the experiment- each line corresponds to a slide name (begins with S - e.g. S20030077) - used in filenames |

--- a/docs/celldive/README.md
+++ b/docs/celldive/README.md
@@ -47,7 +47,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `channel_list\.txt` | ✓ | Information about the capture channels and tags (comma separated) |
 | `slide_list\.txt` | ✓ | Information about the slides used by the experiment- each line corresponds to a slide name (begins with S - e.g. S20030077) - used in filenames |

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -54,21 +54,21 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | example | required? | description |
 | --- | --- | --- |
-| `[^/]+NAV[^/]+\.tif` |  | Navigational Image showing Region of Interest (Keyance Microscope only) |
-| `summary.pdf` | ✓ | **[QA/QC]** PDF export of Powerpoint slide deck containing the Image Analysis Report `.+\.pdf` |
-| `drv_[^/]+/channelNames\.txt` | ✓ | Text file produced by the Akoya software which contains the (linearized) channel number and the Name/ID/Target of the channel (required for HuBMAP pipeline) |
-| `drv_[^/]+/experiment\.json` | ✓ | JSON file produced by the Akoya software which contains the metadata for the experiment, including the software version used, microscope parameters, channel names, pixel dimensions, etc. (required for HuBMAP pipeline) |
-| `drv_[^/]+/exposure_times\.txt` | ✓ | Comma separated text file used for background subtraction that contains valid exposure times for all cycles [e.g: Cycle,CH1,CH2,CH3,CH4]. |
-| `drv_[^/]+/segmentation\.json` | ✓ | JSON file produced by the Akoya software which contains the parameters used for segmentation. (required for HuBMAP pipeline) |
-| `drv_[^/]+/processed_[^/]+/.*` | ✓ | processed files produced by the Akoya software, not used by the HIVE |
-| `src_[^/]+/channelnames_report\.csv` | ✓ | Comma separated text file containing a report of the markers used to map the tissue [e.g. Channel,Name/ID/Target,True/False](required for HuBMAP pipeline) |
-| `src_[^/]+/channelnames\.txt` | ✓ | Text file produced by the Akoya software which contains the (linearized) channel number and the Name/ID/Target of the channel (required for HuBMAP pipeline) |
-| `cyc.*_reg.*_.*/.*_.*_Z.*_CH.*\.tif` | ✓ | TIFF files produced by the experiment. General folder format: Cycle(n)_Region(n)_date; General file format: name_tileNumber(n)_zplaneNumber(n)_channelNumber(n) |
-| `cyc.*_reg.*_.*/.*\.gci` |  | Group Capture Information File (Keyance Microscope only) |
-| `extras/.*` |  | Free-form descriptive information supplied by the TMC |
-| `extras/thumbnail\.(png\|jpg)` |  | Optional thumbnail image which may be shown in search interface |
+| `[^/]+NAV[^/]+\.tif` |  |  | Navigational Image showing Region of Interest (Keyance Microscope only) |
+| `.+\.pdf` | `summary.pdf` | ✓ | **[QA/QC]** PDF export of Powerpoint slide deck containing the Image Analysis Report |
+| `drv_[^/]+/channelNames\.txt` |  | ✓ | Text file produced by the Akoya software which contains the (linearized) channel number and the Name/ID/Target of the channel (required for HuBMAP pipeline) |
+| `drv_[^/]+/experiment\.json` |  | ✓ | JSON file produced by the Akoya software which contains the metadata for the experiment, including the software version used, microscope parameters, channel names, pixel dimensions, etc. (required for HuBMAP pipeline) |
+| `drv_[^/]+/exposure_times\.txt` |  | ✓ | Comma separated text file used for background subtraction that contains valid exposure times for all cycles [e.g: Cycle,CH1,CH2,CH3,CH4]. |
+| `drv_[^/]+/segmentation\.json` |  | ✓ | JSON file produced by the Akoya software which contains the parameters used for segmentation. (required for HuBMAP pipeline) |
+| `drv_[^/]+/processed_[^/]+/.*` |  | ✓ | processed files produced by the Akoya software, not used by the HIVE |
+| `src_[^/]+/channelnames_report\.csv` |  | ✓ | Comma separated text file containing a report of the markers used to map the tissue [e.g. Channel,Name/ID/Target,True/False](required for HuBMAP pipeline) |
+| `src_[^/]+/channelnames\.txt` |  | ✓ | Text file produced by the Akoya software which contains the (linearized) channel number and the Name/ID/Target of the channel (required for HuBMAP pipeline) |
+| `cyc.*_reg.*_.*/.*_.*_Z.*_CH.*\.tif` |  | ✓ | TIFF files produced by the experiment. General folder format: Cycle(n)_Region(n)_date; General file format: name_tileNumber(n)_zplaneNumber(n)_channelNumber(n) |
+| `cyc.*_reg.*_.*/.*\.gci` |  |  | Group Capture Information File (Keyance Microscope only) |
+| `extras/.*` |  |  | Free-form descriptive information supplied by the TMC |
+| `extras/thumbnail\.(png\|jpg)` |  |  | Optional thumbnail image which may be shown in search interface |
 
 ## Provenance
 

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -56,17 +56,20 @@ Related files:
 
 | pattern | example | required? | description |
 | --- | --- | --- |
-| `[^/]+NAV[^/]+\.tif` |  |  | Navigational Image showing Region of Interest (Keyance Microscope only) |
+| `[^/]+NAV[^/]*\.tif` |  |  | Navigational Image showing Region of Interest (Keyance Microscope only) |
 | `.+\.pdf` | `summary.pdf` | ✓ | **[QA/QC]** PDF export of Powerpoint slide deck containing the Image Analysis Report |
 | `drv_[^/]+/channelNames\.txt` |  | ✓ | Text file produced by the Akoya software which contains the (linearized) channel number and the Name/ID/Target of the channel (required for HuBMAP pipeline) |
-| `drv_[^/]+/experiment\.json` |  | ✓ | JSON file produced by the Akoya software which contains the metadata for the experiment, including the software version used, microscope parameters, channel names, pixel dimensions, etc. (required for HuBMAP pipeline) |
-| `drv_[^/]+/exposure_times\.txt` |  | ✓ | Comma separated text file used for background subtraction that contains valid exposure times for all cycles [e.g: Cycle,CH1,CH2,CH3,CH4]. |
-| `drv_[^/]+/segmentation\.json` |  | ✓ | JSON file produced by the Akoya software which contains the parameters used for segmentation. (required for HuBMAP pipeline) |
+| `src_[^/]+/experiment\.json` |  | ✓ | JSON file produced by the Akoya software which contains the metadata for the experiment, including the software version used, microscope parameters, channel names, pixel dimensions, etc. (required for HuBMAP pipeline) |
+| `drv_[^/]+/experiment\.json` |  |  | JSON file produced by the Akoya software which contains the metadata for the experiment, including the software version used, microscope parameters, channel names, pixel dimensions, etc. (required for HuBMAP pipeline) |
+| `src_[^/]+/exposure_times\.txt` |  | ✓ | Comma separated text file used for background subtraction that contains valid exposure times for all cycles [e.g: Cycle,CH1,CH2,CH3,CH4]. |
+| `drv_[^/]+/exposure_times\.txt` |  |  | Comma separated text file used for background subtraction that contains valid exposure times for all cycles [e.g: Cycle,CH1,CH2,CH3,CH4]. |
+| `src_[^/]+/segmentation\.json` |  | ✓ | JSON file produced by the Akoya software which contains the parameters used for segmentation. (required for HuBMAP pipeline) |
+| `drv_[^/]+/segmentation\.json` |  |  | JSON file produced by the Akoya software which contains the parameters used for segmentation. (required for HuBMAP pipeline) |
 | `drv_[^/]+/processed_[^/]+/.*` |  | ✓ | processed files produced by the Akoya software, not used by the HIVE |
 | `src_[^/]+/channelnames_report\.csv` |  | ✓ | Comma separated text file containing a report of the markers used to map the tissue [e.g. Channel,Name/ID/Target,True/False](required for HuBMAP pipeline) |
 | `src_[^/]+/channelnames\.txt` |  | ✓ | Text file produced by the Akoya software which contains the (linearized) channel number and the Name/ID/Target of the channel (required for HuBMAP pipeline) |
-| `cyc.*_reg.*_.*/.*_.*_Z.*_CH.*\.tif` |  | ✓ | TIFF files produced by the experiment. General folder format: Cycle(n)_Region(n)_date; General file format: name_tileNumber(n)_zplaneNumber(n)_channelNumber(n) |
-| `cyc.*_reg.*_.*/.*\.gci` |  |  | Group Capture Information File (Keyance Microscope only) |
+| `src_[^/]+/cyc.*_reg.*_.*/.*_.*_Z.*_CH.*\.tif` |  | ✓ | TIFF files produced by the experiment. General folder format: Cycle(n)_Region(n)_date; General file format: name_tileNumber(n)_zplaneNumber(n)_channelNumber(n) |
+| `src_[^/]+/cyc.*_reg.*_.*/.*\.gci` |  |  | Group Capture Information File (Keyance Microscope only) |
 | `extras/.*` |  |  | Free-form descriptive information supplied by the TMC |
 | `extras/thumbnail\.(png\|jpg)` |  |  | Optional thumbnail image which may be shown in search interface |
 

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -54,10 +54,10 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `[^/]+NAV[^/]+\.tif` |  | Navigational Image showing Region of Interest (Keyance Microscope only) |
-| `.+\.pdf` | ✓ | **[QA/QC]** PDF export of Powerpoint slide deck containing the Image Analysis Report |
+| `summary.pdf` | ✓ | **[QA/QC]** PDF export of Powerpoint slide deck containing the Image Analysis Report `.+\.pdf` |
 | `drv_[^/]+/channelNames\.txt` | ✓ | Text file produced by the Akoya software which contains the (linearized) channel number and the Name/ID/Target of the channel (required for HuBMAP pipeline) |
 | `drv_[^/]+/experiment\.json` | ✓ | JSON file produced by the Akoya software which contains the metadata for the experiment, including the software version used, microscope parameters, channel names, pixel dimensions, etc. (required for HuBMAP pipeline) |
 | `drv_[^/]+/exposure_times\.txt` | ✓ | Comma separated text file used for background subtraction that contains valid exposure times for all cycles [e.g: Cycle,CH1,CH2,CH3,CH4]. |

--- a/docs/imc/README.md
+++ b/docs/imc/README.md
@@ -60,7 +60,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/447 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/imc/README.md
+++ b/docs/imc/README.md
@@ -60,7 +60,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/447 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/lcms/README.md
+++ b/docs/lcms/README.md
@@ -63,7 +63,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/448 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/lcms/README.md
+++ b/docs/lcms/README.md
@@ -63,7 +63,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/448 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/maldiims/README.md
+++ b/docs/maldiims/README.md
@@ -50,7 +50,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `csv/[^/]+\.csv` | ✓ | Intensities M/Z values with Pixel location |
 | `imzML/[^/]+\.ibd` | ✓ | Index to imzML file |

--- a/docs/maldiims/README.md
+++ b/docs/maldiims/README.md
@@ -50,7 +50,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `csv/[^/]+\.csv` | ✓ | Intensities M/Z values with Pixel location |
 | `imzML/[^/]+\.ibd` | ✓ | Index to imzML file |

--- a/docs/mxif/README.md
+++ b/docs/mxif/README.md
@@ -46,7 +46,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/449 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/mxif/README.md
+++ b/docs/mxif/README.md
@@ -46,7 +46,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/449 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/nano/README.md
+++ b/docs/nano/README.md
@@ -46,7 +46,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/450 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/nano/README.md
+++ b/docs/nano/README.md
@@ -46,7 +46,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/450 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/scatacseq/README.md
+++ b/docs/scatacseq/README.md
@@ -63,7 +63,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `.*\.fastq\.gz` | ✓ | TODO: https://github.com/hubmapconsortium/ingest-validation-tools/issues/451 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/scatacseq/README.md
+++ b/docs/scatacseq/README.md
@@ -63,7 +63,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `.*\.fastq\.gz` | ✓ | TODO: https://github.com/hubmapconsortium/ingest-validation-tools/issues/451 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/scrnaseq/README.md
+++ b/docs/scrnaseq/README.md
@@ -61,7 +61,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/452 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/scrnaseq/README.md
+++ b/docs/scrnaseq/README.md
@@ -61,7 +61,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/452 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/seqfish/README.md
+++ b/docs/seqfish/README.md
@@ -52,7 +52,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/453 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/seqfish/README.md
+++ b/docs/seqfish/README.md
@@ -52,7 +52,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/453 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/slideseq/README.md
+++ b/docs/slideseq/README.md
@@ -54,7 +54,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `[^/]+/alignment/Puck_[^/]+\.bam` | ✓ | aligned sequencing data from Slide-seq experiments against reference HG38 |
 | `[^/]+/alignment/Puck_[^/]+_mapping_rate\.txt` | ✓ | mapping rate summary (~ 10 number of mapping statistics per puck) |

--- a/docs/slideseq/README.md
+++ b/docs/slideseq/README.md
@@ -54,7 +54,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `[^/]+/alignment/Puck_[^/]+\.bam` | ✓ | aligned sequencing data from Slide-seq experiments against reference HG38 |
 | `[^/]+/alignment/Puck_[^/]+_mapping_rate\.txt` | ✓ | mapping rate summary (~ 10 number of mapping statistics per puck) |

--- a/docs/stained/README.md
+++ b/docs/stained/README.md
@@ -45,7 +45,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `processedMicroscopy/[^/]+_PAS_images/[^/]+ome\.tif` | ✓ | OME TIFF files (multichannel, multi-layered, image pyramids) produced by the PAS microscopy experiment |
 | `processedMicroscopy/[^/]+_PAS_transformations/[^/]+\.txt` | ✓ | Transformations to PAS (related) data |

--- a/docs/stained/README.md
+++ b/docs/stained/README.md
@@ -45,7 +45,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `processedMicroscopy/[^/]+_PAS_images/[^/]+ome\.tif` | ✓ | OME TIFF files (multichannel, multi-layered, image pyramids) produced by the PAS microscopy experiment |
 | `processedMicroscopy/[^/]+_PAS_transformations/[^/]+\.txt` | ✓ | Transformations to PAS (related) data |

--- a/docs/wgs/README.md
+++ b/docs/wgs/README.md
@@ -50,7 +50,7 @@ Related files:
 
 ## Directory structure
 
-| pattern (regular expression) | required? | description |
+|  | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/455 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/docs/wgs/README.md
+++ b/docs/wgs/README.md
@@ -50,7 +50,7 @@ Related files:
 
 ## Directory structure
 
-|  | required? | description |
+| pattern | required? | description |
 | --- | --- | --- |
 | `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/455 |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |

--- a/src/ingest_validation_tools/directory-schemas/codex.yaml
+++ b/src/ingest_validation_tools/directory-schemas/codex.yaml
@@ -12,6 +12,7 @@
   description: 'Navigational Image showing Region of Interest (Keyance Microscope only)'
   required: False
 -
+  example: 'summary.pdf'
   pattern: '.+\.pdf'
   # TODO: Are we expecting to see this in a particular subdirectory, or at the top level?
   description: 'PDF export of Powerpoint slide deck containing the Image Analysis Report'

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -260,7 +260,7 @@ def _make_dir_description(dir_schema):
     >>> _make_dir_description(dir_schema)
     Traceback (most recent call last):
     ...
-    Exception: Example "ABC123" does not match pattern "[A-Z]\d"
+    Exception: Example "ABC123" does not match pattern "[A-Z]\\d"
 
     '''
     has_examples = any('example' in line for line in dir_schema)

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -224,6 +224,8 @@ def _make_toc(md):
 
 def _make_dir_description(dir_schema):
     '''
+    QA and Required flags are handled:
+
     >>> dir_schema = [
     ...   { 'pattern': 'required\\.txt', 'description': 'Required!',
     ...     'is_qa_qc': True },
@@ -232,36 +234,70 @@ def _make_dir_description(dir_schema):
     ... ]
     >>> print(_make_dir_description(dir_schema))
     <BLANKLINE>
-    |  | required? | description |
+    | pattern | required? | description |
     | --- | --- | --- |
     | `required\\.txt` | ✓ | **[QA/QC]** Required! |
     | `optional\\.txt` |  | Optional! |
 
+    Examples add an extra column:
+
+    >>> dir_schema = [
+    ...   { 'pattern': '[A-Z]+\\d+', 'description': 'letters numbers', 'example': 'ABC123'},
+    ...   { 'pattern': '[A-Z]', 'description': 'one letter, no example'},
+    ... ]
+    >>> print(_make_dir_description(dir_schema))
+    <BLANKLINE>
+    | pattern | example | required? | description |
+    | --- | --- | --- |
+    | `[A-Z]+\\d+` | `ABC123` | ✓ | letters numbers |
+    | `[A-Z]` |  | ✓ | one letter, no example |
+
+    Bad examples cause errors:
+
+    >>> dir_schema = [
+    ...   { 'pattern': '[A-Z]\\d', 'description': '1 letter 1 number', 'example': 'ABC123'},
+    ... ]
+    >>> _make_dir_description(dir_schema)
+    Traceback (most recent call last):
+    ...
+    Exception: Example "ABC123" does not match pattern "[A-Z]\d"
+
     '''
+    has_examples = any('example' in line for line in dir_schema)
+
     output = []
-    output.append('''
-|  | required? | description |
+    if has_examples:
+        output.append('''
+| pattern | example | required? | description |
 | --- | --- | --- |''')
+    else:
+        output.append('''
+| pattern | required? | description |
+| --- | --- | --- |''')
+
     for line in dir_schema:
-        pattern = line["pattern"]
-        if 'example' in line:
-            example = line['example']
-            if not re.fullmatch(pattern, example):
-                raise Exception(f'Example "{example}" does not match pattern "{pattern}"')
-            example_or_pattern = f'`{_md_escape_re(example)}`'
-            pattern_if_needed = f' `{_md_escape_re(pattern)}`'
-        else:
-            example_or_pattern = f'`{_md_escape_re(pattern)}`'
-            pattern_if_needed = ''
+        row = []
 
-        required = '' if 'required' in line and not line['required'] else '✓'
-        qa_qc = '**[QA/QC]** ' if 'is_qa_qc' in line and line['is_qa_qc'] else ''
-        description = qa_qc + line['description'] + pattern_if_needed
+        pattern = line['pattern']
+        pattern_md = f'`{_md_escape_re(pattern)}`'
+        row.append(pattern_md)
 
-        row = [
-            example_or_pattern,
-            required,
-            description
-        ]
+        if has_examples:
+            if 'example' not in line:
+                row.append('')
+            else:
+                example = line['example']
+                if not re.fullmatch(pattern, example):
+                    raise Exception(f'Example "{example}" does not match pattern "{pattern}"')
+                example_md = f'`{_md_escape_re(example)}`'
+                row.append(example_md)
+
+        required_md = '' if 'required' in line and not line['required'] else '✓'
+        row.append(required_md)
+
+        qa_qc_md = '**[QA/QC]** ' if 'is_qa_qc' in line and line['is_qa_qc'] else ''
+        description_md = qa_qc_md + line['description']
+        row.append(description_md)
+
         output.append('| ' + ' | '.join(row) + ' |')
     return '\n'.join(output)


### PR DESCRIPTION
I think there's a proposal that example filenames may be easier for the TMCs to understand that the regexes: This is one way that it could be done. The part to focus on is the `summary.pdf` below:

> |  | required? | description |
> | --- | --- | --- |
> | `[^/]+NAV[^/]+\.tif` |  | Navigational Image showing Region of Interest (Keyance Microscope only) |
> | `.+\.pdf` | ✓ | **[QA/QC]** PDF export of Powerpoint slide deck containing the Image Analysis Report |
> | `summary.pdf` | ✓ | **[QA/QC]** PDF export of Powerpoint slide deck containing the Image Analysis Report `.+\.pdf` |

I'm not sure that examples are going to be provided for everything immediately, so for now the first column might be either a pattern or an example... if it's an example, the actual pattern is relegated to the end of the description. I do check that the provided examples match the regexes.

- Perhaps less confusing to get examples in for everything? ... Though that is a significant bit of work.
- Perhaps better to be consistent and have a separate columns for example and pattern?
