### PR TITLE
Mccalluc/context for decode errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add encoding as CLI param.
 - Add `--offline` option, and use it internally.
 - Fix the CLI parameter parsing: Either `--local_directory` or `--tsv_paths` must be provided.
+- More helpful message if decoding error.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/dataset-examples/bad-codex-data/README.md
+++ b/dataset-examples/bad-codex-data/README.md
@@ -23,6 +23,7 @@ Metadata TSV Errors:
         Internal:
         - The value "bad-id" in row 2 and column 6 ("F") does not conform to the pattern
           constraint of "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
-      row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv: '''ascii''
-        codec can''t decode byte 0xf0 in position 113: ordinal not in range(128)'
+      row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv: "Invalid\
+        \ ascii because ordinal not in range(128): \"mber\tconjugated_tag\n [ \xF0\
+        \ ] \x9F\x98\x83\t\tbad-value\t\t\tinv\""
 ```

--- a/src/ingest_validation_tools/submission.py
+++ b/src/ingest_validation_tools/submission.py
@@ -13,7 +13,8 @@ from ingest_validation_tools.validation_utils import (
     get_data_dir_errors,
     get_contributors_errors,
     get_antibodies_errors,
-    dict_reader_wrapper
+    dict_reader_wrapper,
+    get_context_of_decode_error
 )
 
 from ingest_validation_tools.plugin_validator import (
@@ -146,7 +147,7 @@ class Submission:
         try:
             rows = dict_reader_wrapper(path, self.encoding)
         except UnicodeDecodeError as e:
-            return str(e)
+            return get_context_of_decode_error(e)
         if not rows:
             return 'File has no data rows.'
         if 'data_path' not in rows[0] or 'contributors_path' not in rows[0]:

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -48,6 +48,12 @@ status_of_id: dict = {
 def get_context_of_decode_error(e):
     '''
     >>> try:
+    ...   b'\\xFF'.decode('ascii')
+    ... except UnicodeDecodeError as e:
+    ...   print(get_context_of_decode_error(e))
+    Invalid ascii because ordinal not in range(128): " [ ÿ ] "
+
+    >>> try:
     ...   b'01234\\xFF6789'.decode('ascii')
     ... except UnicodeDecodeError as e:
     ...   print(get_context_of_decode_error(e))

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -45,14 +45,38 @@ status_of_id: dict = {
 }
 
 
+def get_context_of_decode_error(e):
+    '''
+    >>> try:
+    ...   b'01234\\xFF6789'.decode('ascii')
+    ... except UnicodeDecodeError as e:
+    ...   print(get_context_of_decode_error(e))
+    Invalid ascii because ordinal not in range(128): "01234 [ ÿ ] 6789"
+
+    >>> try:
+    ...   (b'a string longer than twenty characters\\xFFa string '
+    ...    b'longer than twenty characters').decode('utf-8')
+    ... except UnicodeDecodeError as e:
+    ...   print(get_context_of_decode_error(e))
+    Invalid utf-8 because invalid start byte: "an twenty characters [ ÿ ] a string longer than"
+
+    '''
+    buffer = 20
+    codec = 'latin-1'  # This is not the actual codec of the string!
+    before = e.object[max(e.start - buffer, 0):max(e.start, 0)].decode(codec)
+    problem = e.object[e.start:e.end].decode(codec)
+    after = e.object[e.end:min(e.end + buffer, len(e.object))].decode(codec)
+    in_context = f'{before} [ {problem} ] {after}'
+    return f'Invalid {e.encoding} because {e.reason}: "{in_context}"'
+
+
 def _get_in_ex_errors(path, type_name, field_url_tuples, encoding=None, offline=None):
     if not path.exists():
         return 'File does not exist'
     try:
         rows = dict_reader_wrapper(path, encoding)
     except UnicodeDecodeError as e:
-        return str(e)
-    rows = dict_reader_wrapper(path, encoding)
+        return get_context_of_decode_error(e)
     if not rows:
         return 'File has no data rows.'
 


### PR DESCRIPTION
Rather than requiring the TMC or the curator to count characters in the file, we can show a little bit of context in the error message. Hope this helps, @cebriggs7135?

@jswelling : My understanding is that machinery downstream hasn't really been designed with anything besides ASCII in mind, so we can make a feature request, but for now, you can't really support non ASCII TSVs, right?

(When there is time to add support, I don't have strong preferences about the encoding to use, except that it shouldn't be latin-1.)