### PR TITLE
sample date -> sample datetime

### DIFF
--- a/src/ingest_validation_tools/table-schemas/sample.yaml
+++ b/src/ingest_validation_tools/table-schemas/sample.yaml
@@ -41,11 +41,9 @@ fields:
   name: procedure_date 
   constraints:
     required: True
-  type: date
-  format: '%Y-%m-%d'
-  description: Date of procedure to procure organ.
-  # https://github.com/hubmapconsortium/ingest-validation-tools/issues/479
-  notes: Originally, not required, but everyone filled it in. This note was present - need to be filled out only if UNET data no available (e.g. live donor). Internal value, not public, optional only for donors without unet info  - TODO - We have no machinery for keeping some fields private... Should this not be included then?
+  type: datetime
+  format: "%Y-%m-%d %H:%M"
+  description: Date and time of procedure to procure organ.
 -
   name: perfusion_solution  
   constraints:


### PR DESCRIPTION
Fix #507; Fix #479?

If this is approved, I can then regenerate the docs, but I have several concerns:

- The request from Chris is straightforward, but it raises the bar on what we're expecting from the TMCs. Is there buy-in from every data provider?
- There was a concern expressed in the note that date alone could make the individual identifiable. Adding time would compound this. If this is approved, then I'd take it that issue (#479) is no longer a concern?
- "date" != "datetime" ... I would prefer to see this field renamed, if this goes forward.