### PR TITLE
upgrade to frictionless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Show the URL that produced the 404, and unify the code.
 - Warning if missing "assay_type".
 - Friendlier error if trying to validate Antibodies or Contributors as metadata.
+- Upgrade to latest version of Frictionless. The content of error messages has changed.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/dataset-examples/bad-codex-data/README.md
+++ b/dataset-examples/bad-codex-data/README.md
@@ -21,8 +21,8 @@ Metadata TSV Errors:
         - src_[^/]+/segmentation\.json
       row 2, contributors dataset-examples/bad-codex-data/submission/contributors.tsv:
         Internal:
-        - The value "bad-id" in row 2 and column 6 ("F") does not conform to the pattern
-          constraint of "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
+        - A field value does not conform to a constraint. On row 2, column "orcid_id",
+          "bad-id" fails because constraint "pattern" is "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
       row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv: "Invalid\
         \ ascii because ordinal not in range(128): \"mber\tconjugated_tag\n [ \xF0\
         \ ] \x9F\x98\x83\t\tbad-value\t\t\tinv\""

--- a/dataset-examples/bad-codex-data/README.md
+++ b/dataset-examples/bad-codex-data/README.md
@@ -21,8 +21,8 @@ Metadata TSV Errors:
         - src_[^/]+/segmentation\.json
       row 2, contributors dataset-examples/bad-codex-data/submission/contributors.tsv:
         Internal:
-        - A field value does not conform to a constraint. On row 2, column "orcid_id",
-          "bad-id" fails because constraint "pattern" is "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
+        - On row 2, column "orcid_id", value "bad-id" fails because constraint "pattern"
+          is "\d{4}-\d{4}-\d{4}-\d{3}[0-9X]"
       row 2, antibodies dataset-examples/bad-codex-data/submission/antibodies.tsv: "Invalid\
         \ ascii because ordinal not in range(128): \"mber\tconjugated_tag\n [ \xF0\
         \ ] \x9F\x98\x83\t\tbad-value\t\t\tinv\""

--- a/dataset-examples/bad-mixed/README.md
+++ b/dataset-examples/bad-mixed/README.md
@@ -2,8 +2,8 @@
 Metadata TSV Errors:
   dataset-examples/bad-mixed/submission/codex-metadata.tsv (as codex):
     Internal:
-    - A field value does not conform to a constraint. On row 2, column "donor_id",
-      "-INVALID-" fails because constraint "pattern" is "[A-Z]+[0-9]+"
+    - On row 2, column "donor_id", value "-INVALID-" fails because constraint "pattern"
+      is "[A-Z]+[0-9]+"
     External:
       row 2, referencing dataset-examples/bad-mixed/submission/bad-shared-dataset:
         Not allowed:
@@ -24,12 +24,12 @@ Metadata TSV Errors:
         does not exist
   dataset-examples/bad-mixed/submission/scatacseq-metadata.tsv (as scatacseq):
     Internal:
-    - A field value does not conform to a constraint. On row 2, column "donor_id",
-      "-INVALID-" fails because constraint "pattern" is "[A-Z]+[0-9]+"
-    - A field value does not conform to a constraint. On row 2, column "sc_isolation_protocols_io_doi",
-      "" fails because constraint "required" is "True"
-    - A field value does not conform to a constraint. On row 2, column "library_construction_protocols_io_doi",
-      "" fails because constraint "required" is "True"
+    - On row 2, column "donor_id", value "-INVALID-" fails because constraint "pattern"
+      is "[A-Z]+[0-9]+"
+    - On row 2, column "sc_isolation_protocols_io_doi", value "" fails because constraint
+      "required" is "True"
+    - On row 2, column "library_construction_protocols_io_doi", value "" fails because
+      constraint "required" is "True"
     External:
       row 2, referencing dataset-examples/bad-mixed/submission/bad-shared-dataset:
         Not allowed:

--- a/dataset-examples/bad-mixed/README.md
+++ b/dataset-examples/bad-mixed/README.md
@@ -2,8 +2,8 @@
 Metadata TSV Errors:
   dataset-examples/bad-mixed/submission/codex-metadata.tsv (as codex):
     Internal:
-    - The value "-INVALID-" in row 2 and column 1 ("A") does not conform to the pattern
-      constraint of "[A-Z]+[0-9]+"
+    - A field value does not conform to a constraint. On row 2, column "donor_id",
+      "-INVALID-" fails because constraint "pattern" is "[A-Z]+[0-9]+"
     External:
       row 2, referencing dataset-examples/bad-mixed/submission/bad-shared-dataset:
         Not allowed:
@@ -24,10 +24,12 @@ Metadata TSV Errors:
         does not exist
   dataset-examples/bad-mixed/submission/scatacseq-metadata.tsv (as scatacseq):
     Internal:
-    - The value "-INVALID-" in row 2 and column 1 ("A") does not conform to the pattern
-      constraint of "[A-Z]+[0-9]+"
-    - Column 17 ("Q") is a required field, but row 2 has no value
-    - Column 27 ("AA") is a required field, but row 2 has no value
+    - A field value does not conform to a constraint. On row 2, column "donor_id",
+      "-INVALID-" fails because constraint "pattern" is "[A-Z]+[0-9]+"
+    - A field value does not conform to a constraint. On row 2, column "sc_isolation_protocols_io_doi",
+      "" fails because constraint "required" is "True"
+    - A field value does not conform to a constraint. On row 2, column "library_construction_protocols_io_doi",
+      "" fails because constraint "required" is "True"
     External:
       row 2, referencing dataset-examples/bad-mixed/submission/bad-shared-dataset:
         Not allowed:

--- a/dataset-examples/bad-scatacseq-data/README.md
+++ b/dataset-examples/bad-scatacseq-data/README.md
@@ -2,8 +2,10 @@
 Metadata TSV Errors:
   dataset-examples/bad-scatacseq-data/submission/scatacseq-metadata.tsv (as scatacseq):
     Internal:
-    - Column 17 ("Q") is a required field, but row 2 has no value
-    - Column 27 ("AA") is a required field, but row 2 has no value
+    - A field value does not conform to a constraint. On row 2, column "sc_isolation_protocols_io_doi",
+      "" fails because constraint "required" is "True"
+    - A field value does not conform to a constraint. On row 2, column "library_construction_protocols_io_doi",
+      "" fails because constraint "required" is "True"
     External:
       row 2, referencing dataset-examples/bad-scatacseq-data/submission/dataset-1:
         Not allowed:

--- a/dataset-examples/bad-scatacseq-data/README.md
+++ b/dataset-examples/bad-scatacseq-data/README.md
@@ -2,10 +2,10 @@
 Metadata TSV Errors:
   dataset-examples/bad-scatacseq-data/submission/scatacseq-metadata.tsv (as scatacseq):
     Internal:
-    - A field value does not conform to a constraint. On row 2, column "sc_isolation_protocols_io_doi",
-      "" fails because constraint "required" is "True"
-    - A field value does not conform to a constraint. On row 2, column "library_construction_protocols_io_doi",
-      "" fails because constraint "required" is "True"
+    - On row 2, column "sc_isolation_protocols_io_doi", value "" fails because constraint
+      "required" is "True"
+    - On row 2, column "library_construction_protocols_io_doi", value "" fails because
+      constraint "required" is "True"
     External:
       row 2, referencing dataset-examples/bad-scatacseq-data/submission/dataset-1:
         Not allowed:

--- a/dataset-examples/bad-tsv-formats/README.md
+++ b/dataset-examples/bad-tsv-formats/README.md
@@ -2,52 +2,45 @@
 Metadata TSV Errors:
   dataset-examples/bad-tsv-formats/submission/codex-metadata.tsv (as codex):
     Internal:
-    - A field value does not conform to a constraint. On row 2, column "donor_id",
-      "not-uuid" fails because constraint "pattern" is "[A-Z]+[0-9]+"
-    - A field value does not conform to a constraint. On row 2, column "tissue_id",
-      "not-uuid" fails because constraint "pattern" is "([A-Z]+[0-9]+)-[A-Z]{2}\d*(-\d+)+(_\d+)?"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "execution_datetime", "not-time" fails because type is "datetime/%Y-%m-%d
-      %H:%M"
-    - A field value does not conform to a constraint. On row 2, column "protocols_io_doi",
-      "10\.17504/protocols.io.menc3de" fails because constraint "pattern" is "10\.17504/.*"
-    - A field value does not conform to a constraint. On row 2, column "analyte_class",
-      "analyte_class" fails because constraint "enum" is "['protein']"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "is_targeted", "is_targeted" fails because type is "boolean/default"
-    - A field value does not conform to a constraint. On row 2, column "acquisition_instrument_vendor",
-      "acquisition_instrument_vendor" fails because constraint "enum" is "['Keyence',
-      'Zeiss']"
-    - A field value does not conform to a constraint. On row 2, column "acquisition_instrument_model",
-      "acquisition_instrument_model" fails because constraint "enum" is "['BZ-X800',
-      'BZ-X710', 'Axio Observer Z1']"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "resolution_x_value", "forty-two" fails because type is "number/default"
-    - A field value does not conform to a constraint. On row 2, column "resolution_x_unit",
-      "inches" fails because constraint "enum" is "['mm', 'um', 'nm']"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "resolution_y_value", "forty-two" fails because type is "number/default"
-    - A field value does not conform to a constraint. On row 2, column "resolution_y_unit",
-      "inches" fails because constraint "enum" is "['mm', 'um', 'nm']"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "resolution_z_value", "forty-two" fails because type is "number/default"
-    - A field value does not conform to a constraint. On row 2, column "resolution_z_unit",
-      "inches" fails because constraint "enum" is "['mm', 'um', 'nm']"
-    - A field value does not conform to a constraint. On row 2, column "preparation_instrument_vendor",
-      "preparation_instrument_vendor" fails because constraint "enum" is "['CODEX']"
-    - A field value does not conform to a constraint. On row 2, column "preparation_instrument_model",
-      "preparation_instrument_model" fails because constraint "enum" is "['version
-      1 robot', 'prototype robot - Stanford/Nolan Lab']"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "number_of_antibodies", "0.5" fails because type is "integer/default"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "number_of_channels", "0.5" fails because type is "integer/default"
-    - The value does not match the schema type and format for this field. On row 2,
-      column "number_of_cycles", "0.5" fails because type is "integer/default"
-    - A field value does not conform to a constraint. On row 2, column "section_prep_protocols_io_doi",
-      "not-doi" fails because constraint "pattern" is "10\.17504/.*"
-    - A field value does not conform to a constraint. On row 2, column "reagent_prep_protocols_io_doi",
-      "not-doi" fails because constraint "pattern" is "10\.17504/.*"
+    - On row 2, column "donor_id", value "not-uuid" fails because constraint "pattern"
+      is "[A-Z]+[0-9]+"
+    - On row 2, column "tissue_id", value "not-uuid" fails because constraint "pattern"
+      is "([A-Z]+[0-9]+)-[A-Z]{2}\d*(-\d+)+(_\d+)?"
+    - On row 2, column "execution_datetime", value "not-time" fails because type is
+      "datetime/%Y-%m-%d %H:%M"
+    - On row 2, column "protocols_io_doi", value "10\.17504/protocols.io.menc3de"
+      fails because constraint "pattern" is "10\.17504/.*"
+    - On row 2, column "analyte_class", value "analyte_class" fails because constraint
+      "enum" is "['protein']"
+    - On row 2, column "is_targeted", value "is_targeted" fails because type is "boolean/default"
+    - On row 2, column "acquisition_instrument_vendor", value "acquisition_instrument_vendor"
+      fails because constraint "enum" is "['Keyence', 'Zeiss']"
+    - On row 2, column "acquisition_instrument_model", value "acquisition_instrument_model"
+      fails because constraint "enum" is "['BZ-X800', 'BZ-X710', 'Axio Observer Z1']"
+    - On row 2, column "resolution_x_value", value "forty-two" fails because type
+      is "number/default"
+    - On row 2, column "resolution_x_unit", value "inches" fails because constraint
+      "enum" is "['mm', 'um', 'nm']"
+    - On row 2, column "resolution_y_value", value "forty-two" fails because type
+      is "number/default"
+    - On row 2, column "resolution_y_unit", value "inches" fails because constraint
+      "enum" is "['mm', 'um', 'nm']"
+    - On row 2, column "resolution_z_value", value "forty-two" fails because type
+      is "number/default"
+    - On row 2, column "resolution_z_unit", value "inches" fails because constraint
+      "enum" is "['mm', 'um', 'nm']"
+    - On row 2, column "preparation_instrument_vendor", value "preparation_instrument_vendor"
+      fails because constraint "enum" is "['CODEX']"
+    - On row 2, column "preparation_instrument_model", value "preparation_instrument_model"
+      fails because constraint "enum" is "['version 1 robot', 'prototype robot - Stanford/Nolan
+      Lab']"
+    - On row 2, column "number_of_antibodies", value "0.5" fails because type is "integer/default"
+    - On row 2, column "number_of_channels", value "0.5" fails because type is "integer/default"
+    - On row 2, column "number_of_cycles", value "0.5" fails because type is "integer/default"
+    - On row 2, column "section_prep_protocols_io_doi", value "not-doi" fails because
+      constraint "pattern" is "10\.17504/.*"
+    - On row 2, column "reagent_prep_protocols_io_doi", value "not-doi" fails because
+      constraint "pattern" is "10\.17504/.*"
     External:
       row 2, referencing dataset-examples/bad-tsv-formats/submission/dataset-1:
         Not allowed:

--- a/dataset-examples/bad-tsv-formats/README.md
+++ b/dataset-examples/bad-tsv-formats/README.md
@@ -2,54 +2,52 @@
 Metadata TSV Errors:
   dataset-examples/bad-tsv-formats/submission/codex-metadata.tsv (as codex):
     Internal:
-    - The value "not-uuid" in row 2 and column 1 ("A") does not conform to the pattern
-      constraint of "[A-Z]+[0-9]+"
-    - The value "not-uuid" in row 2 and column 2 ("B") does not conform to the pattern
-      constraint of "([A-Z]+[0-9]+)-[A-Z]{2}\d*(-\d+)+(_\d+)?"
-    - The value "not-time" in row 2 and column 3 ("C") is not type "datetime" and
-      format "%Y-%m-%d %H:%M"
-    - The value "10\.17504/protocols.io.menc3de" in row 2 and column 4 ("D") does
-      not conform to the pattern constraint of "10\.17504/.*"
-    - The value "operator_emailATexample.com" in row 2 and column 6 ("F") is not type
-      "string" and format "email"
-    - The value "pi_emailATexample.com" in row 2 and column 8 ("H") is not type "string"
-      and format "email"
-    - 'The value "analyte_class" in row 2 and column 11 ("K") does not conform to
-      the given enumeration: "[''protein'']"'
-    - The value "is_targeted" in row 2 and column 12 ("L") is not type "boolean" and
-      format "default"
-    - 'The value "acquisition_instrument_vendor" in row 2 and column 13 ("M") does
-      not conform to the given enumeration: "[''Keyence'', ''Zeiss'']"'
-    - 'The value "acquisition_instrument_model" in row 2 and column 14 ("N") does
-      not conform to the given enumeration: "[''BZ-X800'', ''BZ-X710'', ''Axio Observer
-      Z1'']"'
-    - The value "forty-two" in row 2 and column 15 ("O") is not type "number" and
-      format "default"
-    - 'The value "inches" in row 2 and column 16 ("P") does not conform to the given
-      enumeration: "[''mm'', ''um'', ''nm'']"'
-    - The value "forty-two" in row 2 and column 17 ("Q") is not type "number" and
-      format "default"
-    - 'The value "inches" in row 2 and column 18 ("R") does not conform to the given
-      enumeration: "[''mm'', ''um'', ''nm'']"'
-    - The value "forty-two" in row 2 and column 19 ("S") is not type "number" and
-      format "default"
-    - 'The value "inches" in row 2 and column 20 ("T") does not conform to the given
-      enumeration: "[''mm'', ''um'', ''nm'']"'
-    - 'The value "preparation_instrument_vendor" in row 2 and column 21 ("U") does
-      not conform to the given enumeration: "[''CODEX'']"'
-    - 'The value "preparation_instrument_model" in row 2 and column 22 ("V") does
-      not conform to the given enumeration: "[''version 1 robot'', ''prototype robot
-      - Stanford/Nolan Lab'']"'
-    - The value "0.5" in row 2 and column 23 ("W") is not type "integer" and format
-      "default"
-    - The value "0.5" in row 2 and column 24 ("X") is not type "integer" and format
-      "default"
-    - The value "0.5" in row 2 and column 25 ("Y") is not type "integer" and format
-      "default"
-    - The value "not-doi" in row 2 and column 26 ("Z") does not conform to the pattern
-      constraint of "10\.17504/.*"
-    - The value "not-doi" in row 2 and column 27 ("AA") does not conform to the pattern
-      constraint of "10\.17504/.*"
+    - A field value does not conform to a constraint. On row 2, column "donor_id",
+      "not-uuid" fails because constraint "pattern" is "[A-Z]+[0-9]+"
+    - A field value does not conform to a constraint. On row 2, column "tissue_id",
+      "not-uuid" fails because constraint "pattern" is "([A-Z]+[0-9]+)-[A-Z]{2}\d*(-\d+)+(_\d+)?"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "execution_datetime", "not-time" fails because type is "datetime/%Y-%m-%d
+      %H:%M"
+    - A field value does not conform to a constraint. On row 2, column "protocols_io_doi",
+      "10\.17504/protocols.io.menc3de" fails because constraint "pattern" is "10\.17504/.*"
+    - A field value does not conform to a constraint. On row 2, column "analyte_class",
+      "analyte_class" fails because constraint "enum" is "['protein']"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "is_targeted", "is_targeted" fails because type is "boolean/default"
+    - A field value does not conform to a constraint. On row 2, column "acquisition_instrument_vendor",
+      "acquisition_instrument_vendor" fails because constraint "enum" is "['Keyence',
+      'Zeiss']"
+    - A field value does not conform to a constraint. On row 2, column "acquisition_instrument_model",
+      "acquisition_instrument_model" fails because constraint "enum" is "['BZ-X800',
+      'BZ-X710', 'Axio Observer Z1']"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "resolution_x_value", "forty-two" fails because type is "number/default"
+    - A field value does not conform to a constraint. On row 2, column "resolution_x_unit",
+      "inches" fails because constraint "enum" is "['mm', 'um', 'nm']"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "resolution_y_value", "forty-two" fails because type is "number/default"
+    - A field value does not conform to a constraint. On row 2, column "resolution_y_unit",
+      "inches" fails because constraint "enum" is "['mm', 'um', 'nm']"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "resolution_z_value", "forty-two" fails because type is "number/default"
+    - A field value does not conform to a constraint. On row 2, column "resolution_z_unit",
+      "inches" fails because constraint "enum" is "['mm', 'um', 'nm']"
+    - A field value does not conform to a constraint. On row 2, column "preparation_instrument_vendor",
+      "preparation_instrument_vendor" fails because constraint "enum" is "['CODEX']"
+    - A field value does not conform to a constraint. On row 2, column "preparation_instrument_model",
+      "preparation_instrument_model" fails because constraint "enum" is "['version
+      1 robot', 'prototype robot - Stanford/Nolan Lab']"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "number_of_antibodies", "0.5" fails because type is "integer/default"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "number_of_channels", "0.5" fails because type is "integer/default"
+    - The value does not match the schema type and format for this field. On row 2,
+      column "number_of_cycles", "0.5" fails because type is "integer/default"
+    - A field value does not conform to a constraint. On row 2, column "section_prep_protocols_io_doi",
+      "not-doi" fails because constraint "pattern" is "10\.17504/.*"
+    - A field value does not conform to a constraint. On row 2, column "reagent_prep_protocols_io_doi",
+      "not-doi" fails because constraint "pattern" is "10\.17504/.*"
     External:
       row 2, referencing dataset-examples/bad-tsv-formats/submission/dataset-1:
         Not allowed:

--- a/dataset-iec-examples/bad-example/README.md
+++ b/dataset-iec-examples/bad-example/README.md
@@ -1,4 +1,4 @@
-In metadata.tsv, a field value does not conform to a constraint. On row 2, column "donor_id", "bad-donor-id" fails because constraint "pattern" is "[A-Z]+[0-9]+".
+In metadata.tsv, on row 2, column "donor_id", value "bad-donor-id" fails because constraint "pattern" is "[A-Z]+[0-9]+".
 In the dataset dataset-iec-examples/bad-example/submission referenced on row 2, the file "should-not-be-here.txt" is not allowed.
 In the contributors dataset-iec-examples/bad-example/submission/extras/contributors.tsv referenced on row 2, row 2, orcid_id: https://orcid.org/0000-0000-0000-0000 is 404.
 In metadata.tsv (as scatacseq): External: row 2, protocols_io_doi: https://dx.doi.org/10.17504/fake is 404.

--- a/dataset-iec-examples/bad-example/README.md
+++ b/dataset-iec-examples/bad-example/README.md
@@ -1,4 +1,4 @@
-In metadata.tsv, the value "bad-donor-id" in row 2 and column 1 ("A") is not the right form.
+In metadata.tsv, a field value does not conform to a constraint. On row 2, column "donor_id", "bad-donor-id" fails because constraint "pattern" is "[A-Z]+[0-9]+".
 In the dataset dataset-iec-examples/bad-example/submission referenced on row 2, the file "should-not-be-here.txt" is not allowed.
 In the contributors dataset-iec-examples/bad-example/submission/extras/contributors.tsv referenced on row 2, row 2, orcid_id: https://orcid.org/0000-0000-0000-0000 is 404.
 In metadata.tsv (as scatacseq): External: row 2, protocols_io_doi: https://dx.doi.org/10.17504/fake is 404.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 files = src/ingest_validation_tools/plugin_validator.py
 
-[mypy-goodtables.*]
+[mypy-frictionless.*]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 jsonschema==3.2.0
 pyyaml>=5.3.1
-tableschema==1.15.0
-goodtables==2.4.9
+frictionless==3.48.0
 yattag==1.14.0
 tableschema-to-template==0.0.11
 requests==2.25.0

--- a/sample-examples/bad-sample/README.md
+++ b/sample-examples/bad-sample/README.md
@@ -1,13 +1,12 @@
 ```
 Sample TSV Errors:
-- A field value does not conform to a constraint. On row 2, column "sample_id", ""
-  fails because constraint "required" is "True"
-- A field value does not conform to a constraint. On row 2, column "procedure_date",
-  "" fails because constraint "required" is "True"
-- A field value does not conform to a constraint. On row 2, column "pathologist_report",
-  "" fails because constraint "required" is "True"
-- A field value does not conform to a constraint. On row 2, column "specimen_preservation_temperature",
-  "-196 Celsius / -80 Celsius / -20 Celsius / Room Temperature" fails because constraint
-  "enum" is "['Liquid Nitrogen', 'Liquid Nitrogen Vapor', 'Freezer (-80 Celsius)',
-  'Freezer (-20 Celsius)', 'Room Temperature']"
+- On row 2, column "sample_id", value "" fails because constraint "required" is "True"
+- On row 2, column "procedure_date", value "" fails because constraint "required"
+  is "True"
+- On row 2, column "pathologist_report", value "" fails because constraint "required"
+  is "True"
+- On row 2, column "specimen_preservation_temperature", value "-196 Celsius / -80
+  Celsius / -20 Celsius / Room Temperature" fails because constraint "enum" is "['Liquid
+  Nitrogen', 'Liquid Nitrogen Vapor', 'Freezer (-80 Celsius)', 'Freezer (-20 Celsius)',
+  'Room Temperature']"
 ```

--- a/sample-examples/bad-sample/README.md
+++ b/sample-examples/bad-sample/README.md
@@ -1,10 +1,13 @@
 ```
 Sample TSV Errors:
-- Column 1 ("A") is a required field, but row 2 has no value
-- Column 5 ("E") is a required field, but row 2 has no value
-- Column 7 ("G") is a required field, but row 2 has no value
-- 'The value "-196 Celsius / -80 Celsius / -20 Celsius / Room Temperature" in row
-  2 and column 12 ("L") does not conform to the given enumeration: "[''Liquid Nitrogen'',
-  ''Liquid Nitrogen Vapor'', ''Freezer (-80 Celsius)'', ''Freezer (-20 Celsius)'',
-  ''Room Temperature'']"'
+- A field value does not conform to a constraint. On row 2, column "sample_id", ""
+  fails because constraint "required" is "True"
+- A field value does not conform to a constraint. On row 2, column "procedure_date",
+  "" fails because constraint "required" is "True"
+- A field value does not conform to a constraint. On row 2, column "pathologist_report",
+  "" fails because constraint "required" is "True"
+- A field value does not conform to a constraint. On row 2, column "specimen_preservation_temperature",
+  "-196 Celsius / -80 Celsius / -20 Celsius / Room Temperature" fails because constraint
+  "enum" is "['Liquid Nitrogen', 'Liquid Nitrogen Vapor', 'Freezer (-80 Celsius)',
+  'Freezer (-20 Celsius)', 'Room Temperature']"
 ```

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -126,6 +126,8 @@ def _make_constraints_table(field):
     table_md_rows = ['| constraint | value |', '| --- | --- |']
     for key, value in field.items():
         if key in ['type', 'format']:
+            if key == 'type' and value == 'string':
+                continue
             table_md_rows.append(f'| {key} | `{value}` |')
     if 'constraints' in field:
         for key, value in field['constraints'].items():

--- a/src/ingest_validation_tools/schema_loader.py
+++ b/src/ingest_validation_tools/schema_loader.py
@@ -183,7 +183,7 @@ def _add_constraints(field, optional_fields):
     >>> pprint(field, width=40)
     {'constraints': {'pattern': 'fake-regex',
                      'required': True},
-     'name': 'optional_value',
+     'name': 'whatever',
      'type': 'string'}
 
     '''

--- a/src/ingest_validation_tools/schema_loader.py
+++ b/src/ingest_validation_tools/schema_loader.py
@@ -178,6 +178,14 @@ def _add_constraints(field, optional_fields):
      'name': 'optional_value',
      'type': 'number'}
 
+    >>> field = {'name': 'whatever', 'constraints': {'pattern': 'fake-regex'}}
+    >>> _add_constraints(field, [])
+    >>> pprint(field, width=40)
+    {'constraints': {'pattern': 'fake-regex',
+                     'required': True},
+     'name': 'optional_value',
+     'type': 'string'}
+
     '''
     if 'constraints' not in field:
         field['constraints'] = {}
@@ -201,6 +209,8 @@ def _add_constraints(field, optional_fields):
         field['type'] = 'number'
         field['constraints']['minimum'] = 0
         field['constraints']['maximum'] = 100
+    if 'pattern' in field['constraints']:
+        field['type'] = 'string'
 
     # Override:
     if field['name'] in optional_fields:

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -1,6 +1,4 @@
 import logging
-import re
-from string import ascii_uppercase
 from csv import DictReader
 from pathlib import Path
 
@@ -165,21 +163,23 @@ def get_tsv_errors(tsv_path, type, optional_fields=[]):
 
 def _get_message(error):
     '''
-    >>> _get_message({
+    >>> m = _get_message({
     ...     'cell': 'bad-id',
     ...     'fieldName': 'orcid_id',
     ...     'fieldNumber': 6,
     ...     'fieldPosition': 6,
     ...     'rowNumber': 1,
     ...     'rowPosition': 2,
-    ...     'note': 'constraint "pattern" is "\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]"',
+    ...     'note': 'constraint "pattern" is "fake-re"',
     ...     'message': 'The message from the library is a bit confusing!',
     ...     'description': 'A field value does not conform to a constraint.'
-    ... })
-    'A field value does not conform to a constraint. On row 2, "orcid_id" column, "bad-id" fails because constraint "pattern" is "\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]"'
-    
+    ... }).split('.')
+    >>> print('\\n'.join(m))
+    A field value does not conform to a constraint
+     On row 2, column "orcid_id", "bad-id" fails because constraint "pattern" is "fake-re"
+
     '''
-    
+
     return (
         f'{error["description"]} On row {error["rowPosition"]}, column "{error["fieldName"]}", '
         f'"{error["cell"]}" fails because {error["note"]}'

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -163,7 +163,7 @@ def get_tsv_errors(tsv_path, type, optional_fields=[]):
 
 def _get_message(error):
     '''
-    >>> m = _get_message({
+    >>> print(_get_message({
     ...     'cell': 'bad-id',
     ...     'fieldName': 'orcid_id',
     ...     'fieldNumber': 6,
@@ -173,14 +173,12 @@ def _get_message(error):
     ...     'note': 'constraint "pattern" is "fake-re"',
     ...     'message': 'The message from the library is a bit confusing!',
     ...     'description': 'A field value does not conform to a constraint.'
-    ... }).split('.')
-    >>> print('\\n'.join(m))
-    A field value does not conform to a constraint
-     On row 2, column "orcid_id", "bad-id" fails because constraint "pattern" is "fake-re"
+    ... }))
+    On row 2, column "orcid_id", value "bad-id" fails because constraint "pattern" is "fake-re"
 
     '''
 
     return (
-        f'{error["description"]} On row {error["rowPosition"]}, column "{error["fieldName"]}", '
-        f'"{error["cell"]}" fails because {error["note"]}'
+        f'On row {error["rowPosition"]}, column "{error["fieldName"]}", '
+        f'value "{error["cell"]}" fails because {error["note"]}'
     )

--- a/test-cli.py
+++ b/test-cli.py
@@ -23,6 +23,7 @@ def validate(args):
     cmd = [
         'src/validate_submission.py', '--output', 'as_text'
     ] + args.split(' ')
+    print('Running: ' + ' '.join(cmd))
     subprocess.run(
         cmd, check=True)
 

--- a/test-dataset-examples.sh
+++ b/test-dataset-examples.sh
@@ -5,7 +5,7 @@ red=`tput setaf 1`
 reset=`tput sgr0`
 die() { set +v; echo "$red$*$reset" 1>&2 ; exit 1; }
 
-for SUITE in dataset-iec-examples dataset-examples; do
+for SUITE in dataset-examples dataset-iec-examples; do
 
   case $SUITE in
     dataset-iec-examples)


### PR DESCRIPTION
With an upgrade to the latest version of Frictionless, the format of the error messages it returns has changed. I don't really like the strings it returns by default, so I'm composing a message from the fields it supplies.

@cebriggs7135 : Do these messages look ok? Would you like the error message for missing required fields to be a bit more concise? Does anything else strike you?
@ilan-gold : For code reviews, I've sometimes been going to Joel, but I think I should try to spread familiarity with the code base across the team. Does learning about (and making suggestions about) this repo seem ok to you?

Fix #497

Filed #526 (I think the new version sniffs to determine the TSV/CSV type... but the code that ultimately consumes the data is probably more brittle.)