### PR TITLE
no more stand-alone TSV validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add flowchart documenting the consensus submission process.
 - cleanup-whitespace.py
 - Issue templates to operationalize new process for handling post-release changes.
+- Remove option to just validate TSVs.
 
 ## v0.0.7 - 2021-01-13
 - Improved error messages in Excel.

--- a/README-validate_submission.py.md
+++ b/README-validate_submission.py.md
@@ -1,6 +1,5 @@
 ```
-usage: validate_submission.py [-h]
-                              (--local_directory PATH | --tsv_paths PATH [PATH ...])
+usage: validate_submission.py [-h] --local_directory PATH
                               [--optional_fields FIELD [FIELD ...]]
                               [--offline]
                               [--dataset_ignore_globs GLOB [GLOB ...]]
@@ -10,15 +9,12 @@ usage: validate_submission.py [-h]
                               [--output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}]
                               [--add_notes]
 
-Validate a HuBMAP submission, both the metadata TSVs, and the datasets,
-either local or remote, or a combination of the two.
+Validates a HuBMAP submission, both the metadata TSVs and the datasets.
 
 optional arguments:
   -h, --help            show this help message and exit
   --local_directory PATH
                         Local directory to validate
-  --tsv_paths PATH [PATH ...]
-                        Paths of metadata.tsv files.
   --optional_fields FIELD [FIELD ...]
                         The listed fields will be treated as optional. (But if
                         they are supplied in the TSV, they will be validated.)
@@ -39,10 +35,8 @@ optional arguments:
   --add_notes           Append a context note to error reports.
 
 Typical usecases:
-  --tsv_paths: Used to validate TSVs in isolation, without checking references.
-
-  --local_directory: Used in development against test fixtures, and could be used
-  by labs before submission.
+  --local_directory: Used in development against test fixtures,
+  and by labs before submission.
 
   --local_directory + --dataset_ignore_globs + --submission_ignore_globs:
   Currently, during ingest, the metadata TSVs are broken up, and one-line TSVs

--- a/src/ingest_validation_tools/submission.py
+++ b/src/ingest_validation_tools/submission.py
@@ -42,7 +42,7 @@ class PreflightError(Exception):
 
 
 class Submission:
-    def __init__(self, directory_path=None, tsv_paths=[],
+    def __init__(self, directory_path=None,
                  optional_fields=[], add_notes=True,
                  dataset_ignore_globs=[], submission_ignore_globs=[],
                  plugin_directory=None, encoding=None, offline=None):
@@ -58,10 +58,7 @@ class Submission:
         try:
             unsorted_effective_tsv_paths = {
                 str(path): self._get_type_from_first_line(path)
-                for path in (
-                    tsv_paths if tsv_paths
-                    else directory_path.glob(f'*{TSV_SUFFIX}')
-                )
+                for path in directory_path.glob(f'*{TSV_SUFFIX}')
             }
             self.effective_tsv_paths = {
                 k: unsorted_effective_tsv_paths[k]

--- a/src/validate_submission.py
+++ b/src/validate_submission.py
@@ -20,15 +20,11 @@ directory_schemas = sorted({
 
 def make_parser():
     parser = argparse.ArgumentParser(
-        description='''
-Validate a HuBMAP submission, both the metadata TSVs, and the datasets,
-either local or remote, or a combination of the two.''',
+        description='Validates a HuBMAP submission, both the metadata TSVs and the datasets.',
         epilog='''
 Typical usecases:
-  --tsv_paths: Used to validate TSVs in isolation, without checking references.
-
-  --local_directory: Used in development against test fixtures, and could be used
-  by labs before submission.
+  --local_directory: Used in development against test fixtures,
+  and by labs before submission.
 
   --local_directory + --dataset_ignore_globs + --submission_ignore_globs:
   Currently, during ingest, the metadata TSVs are broken up, and one-line TSVs
@@ -39,15 +35,10 @@ Typical usecases:
 
     # What should be validated?
 
-    mutex_group = parser.add_mutually_exclusive_group(required=True)
-    mutex_group.add_argument(
-        '--local_directory', type=argparse_types.dir_path,
+    parser.add_argument(
+        '--local_directory', type=argparse_types.dir_path, required=True,
         metavar='PATH',
         help='Local directory to validate')
-    mutex_group.add_argument(
-        '--tsv_paths', nargs='+',
-        metavar='PATH',
-        help='Paths of metadata.tsv files.')
 
     # Should validation be loosened?
 
@@ -108,17 +99,8 @@ Typical usecases:
 parser = make_parser()
 
 
-def parse_args():
-    args = parser.parse_args()
-    if not (args.tsv_paths or args.local_directory):
-        raise ShowUsageException(
-            'Either local file or local directory is required')
-
-    return args
-
-
 def main():
-    args = parse_args()
+    args = parser.parse_args()
     submission_args = {
         'add_notes': args.add_notes,
         'encoding': args.encoding,
@@ -128,10 +110,6 @@ def main():
 
     if args.local_directory:
         submission_args['directory_path'] = Path(args.local_directory)
-
-    if args.tsv_paths:
-        submission_args['tsv_paths'] = args.tsv_paths
-
     if args.dataset_ignore_globs:
         submission_args['dataset_ignore_globs'] = \
             args.dataset_ignore_globs

--- a/test-cli.py
+++ b/test-cli.py
@@ -8,11 +8,9 @@ import subprocess
 good_args = [
     '--local_directory dataset-examples/good-scatacseq/submission/ '
     '--dataset_ignore_globs ignore-*.tsv .* '
-    '--submission_ignore_globs drv_ignore_*',
+    '--submission_ignore_globs drv_ignore_*'
     # NOTE: When called from the shell,
     # remember to quote '*' arguments to prevent expansion.
-
-    '--tsv_paths dataset-examples/good-scatacseq/submission/metadata.tsv'
 ]
 bad_args = [
     '--bad',


### PR DESCRIPTION
The stand-alone TSV validation is not part of any workflow now, and I think its continued availability will cause confusion: It makes it unclear what "validated" means. If someone *really* needs to validate an isolated TSV, they can drop it into an empty directory and validate that, and only look at the errors from the TSV.