### PR TITLE
Update to IMC yaml- removed 2 redundant datetime fields

### DIFF
--- a/src/ingest_validation_tools/table-schemas/level-2/imc.yaml
+++ b/src/ingest_validation_tools/table-schemas/level-2/imc.yaml
@@ -73,10 +73,6 @@ fields:
 - name: dual_count_start
   description: Threshold for dual counting.
   type: number
-- name: end_datetime
-  description: Time stamp indicating end of ablation for ROI
-  type: datetime
-  format: "%Y-%m-%d %H:%M"
 - name: max_x_width_value
   description: Image width value of the ROI acquisition
   type: number
@@ -107,10 +103,6 @@ fields:
       - dual count
       - pulse count
       - intensity value
-- name: start_datetime
-  description: Time stamp indicating start of ablation for ROI
-  type: datetime
-  format: "%Y-%m-%d %H:%M"
 - name: data_precision_bytes
   description: Numerical data precision in bytes
   type: number


### PR DESCRIPTION
The IMC schema includes 2 datetime fields that are not necessary. The execution_datetime field captures the start_datetime and the end_datetime is not relevant. I have removed these 2 fields:

start_datetime and end_datetime
Per 2/19/21 conversation with the IMC team from UFLA/Zurich: