### PR TITLE
Mccalluc/atacseq dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix typo in nano enum.
 - Clearer error when it can't find matching assay name.
 - Downgrade dependency for compatibility with HuBMAP commons.
+- Directory structure for scatacseq.
 
 ## v0.0.8 - 2021-02-10
 - Update CODEX directory structure

--- a/dataset-examples/bad-mixed/README.md
+++ b/dataset-examples/bad-mixed/README.md
@@ -34,8 +34,6 @@ Metadata TSV Errors:
       row 2, referencing dataset-examples/bad-mixed/submission/bad-shared-dataset:
         Not allowed:
         - not-good-for-either-type.txt
-        Required but missing:
-        - .*\.fastq\.gz
       row 2, contributors dataset-examples/bad-mixed/submission/contributors.tsv: File
         has no data rows.
 Reference Errors:

--- a/dataset-examples/bad-scatacseq-data/README.md
+++ b/dataset-examples/bad-scatacseq-data/README.md
@@ -11,6 +11,4 @@ Metadata TSV Errors:
         Not allowed:
         - not-the-file-you-are-looking-for.txt
         - unexpected-directory/place-holder.txt
-        Required but missing:
-        - .*\.fastq\.gz
 ```

--- a/docs/scatacseq/README.md
+++ b/docs/scatacseq/README.md
@@ -65,7 +65,8 @@ Related files:
 
 | pattern | required? | description |
 | --- | --- | --- |
-| `.*\.fastq\.gz` | ✓ | TODO: https://github.com/hubmapconsortium/ingest-validation-tools/issues/451 |
+| `[^/]+\.fastq\.gz` |  | Compressed FastQ file |
+| `[^/]+\.fastq` |  | FastQ file |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |
 | `extras/thumbnail\.(png\|jpg)` |  | Optional thumbnail image which may be shown in search interface |
 

--- a/src/ingest_validation_tools/directory-schemas/scatacseq.yaml
+++ b/src/ingest_validation_tools/directory-schemas/scatacseq.yaml
@@ -1,3 +1,12 @@
+# ATAC-seq description
+# https://portal.hubmapconsortium.org/docs/assays/atacseq
+#
+# This directory structure schema applies to these assay-types
+# - SNARE-seq2
+# - scATACseq
+# - sciATACseq
+# - snATACseq
+
 -
   pattern: '[^/]+\.fastq\.gz'
   description: 'Compressed FastQ file'

--- a/src/ingest_validation_tools/directory-schemas/scatacseq.yaml
+++ b/src/ingest_validation_tools/directory-schemas/scatacseq.yaml
@@ -1,4 +1,8 @@
 -
-  pattern: '.*\.fastq\.gz'
-  description: 'TODO: https://github.com/hubmapconsortium/ingest-validation-tools/issues/451'
-
+  pattern: '[^/]+\.fastq\.gz'
+  description: 'Compressed FastQ file'
+  required: False
+-
+  pattern: '[^/]+\.fastq'
+  description: 'FastQ file'
+  required: False


### PR DESCRIPTION
Replacement for #581, after talking with Ivan. Because both patterns are optional (a dataset could be only `.fastq` or only `fastq.gz`), the missing file warning is longer generated in a couple test fixtures.

... if some warning should be presented, the pattern could be changed to 
```
[^/]+\.fastq(\.gz)?
```
... but I think the status quo is fine.

Fix #451 