### PR TITLE
make as_text_list the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Downgrade dependency for compatibility with HuBMAP commons.
 - Directory structure for scatacseq.
 - Factor out the checks, make OO, and make error messages configurable.
+- Make as_text_list the default output format.
 
 ## v0.0.8 - 2021-02-10
 - Update CODEX directory structure

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You should see [the documention for `validate_submission.py`](README-validate_su
 
 Now run it against one of the included examples, giving the path to a submission directory:
 ```
-src/validate_submission.py --local_directory dataset-examples/bad-tsv-formats/submission
+src/validate_submission.py --local_directory dataset-examples/bad-tsv-formats/submission --as_text
 ```
 
 You should now see [this (extensive) error message](dataset-examples/bad-tsv-formats/README.md).

--- a/src/validate_submission.py
+++ b/src/validate_submission.py
@@ -95,7 +95,7 @@ Typical usage:
         if name.startswith('as_')
     ]
     parser.add_argument('--output', choices=error_report_methods,
-                        default='as_text')
+                        default='as_text_list')
 
     parser.add_argument('--add_notes', action='store_true',
                         help='Append a context note to error reports.')

--- a/test-dataset-examples.sh
+++ b/test-dataset-examples.sh
@@ -9,7 +9,7 @@ for SUITE in dataset-examples dataset-iec-examples; do
 
   case $SUITE in
     dataset-iec-examples)
-      OPTS="--dataset_ignore_globs 'metadata.tsv' --submission_ignore_globs '*' --output as_text_list"
+      OPTS="--dataset_ignore_globs 'metadata.tsv' --submission_ignore_globs '*'"
       ;;
     dataset-examples)
       # To minimize dependence on outside resources, --offline used here,


### PR DESCRIPTION
I remembered to ask Chris, and she concurs with Bill that the flat list is the easier format for typical end users to read. I'm not really convinced of this, but I'm also not the best judge, so this makes it the default. No tests needed to be changed, because nowhere were we just using the default: Instead, `as_md` was used everywhere. I've removed `as_flat_list` in one test, because it is now the default.

I'm not sure what Airflow uses, but it should probably be consistent?

fix #596 

cc @cebriggs7135 