### PR TITLE
Modify table schemas to accept SNARE2-ATACseq as an assay name

### DIFF
--- a/src/ingest_validation_tools/table-schemas/assays/scatacseq-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scatacseq-v0.yaml
@@ -14,6 +14,7 @@ fields:
         - scATACseq
         - sciATACseq
         - snATACseq
+        - SNARE2-ATACseq
   -
     name: analyte_class
     constraints:

--- a/src/ingest_validation_tools/table-schemas/assays/scatacseq-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scatacseq-v0.yaml
@@ -10,11 +10,10 @@ fields:
     name: assay_type
     constraints:
       enum:
-        - SNARE-seq2
         - scATACseq
         - sciATACseq
         - snATACseq
-        - SNARE2-ATACseq
+        - SNARE-ATACseq2
   -
     name: analyte_class
     constraints:

--- a/src/ingest_validation_tools/table-schemas/assays/scatacseq-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scatacseq-v1.yaml
@@ -14,6 +14,7 @@ fields:
         - scATACseq
         - sciATACseq
         - snATACseq
+        - SNARE2-ATACseq
   -
     name: analyte_class
     constraints:

--- a/src/ingest_validation_tools/table-schemas/assays/scatacseq-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scatacseq-v1.yaml
@@ -10,11 +10,10 @@ fields:
     name: assay_type
     constraints:
       enum:
-        - SNARE-seq2
         - scATACseq
         - sciATACseq
         - snATACseq
-        - SNARE2-ATACseq
+        - SNARE-ATACseq2
   -
     name: analyte_class
     constraints:


### PR DESCRIPTION
This PR updates the table schemas to recognize the assay name SNARE2-ATACseq, introduced in https://github.com/hubmapconsortium/search-api/pull/317 .