### PR TITLE
Mccalluc/loop reference errors reorder

### DIFF
--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -63,6 +63,12 @@ class Upload:
             raise PreflightError(f'{path} has no data rows.')
         return get_schema_version_from_row(path, rows[0])
 
+    #####################
+    #
+    # One public method:
+    #
+    #####################
+
     def get_errors(self):
         # This creates a deeply nested dict.
         # Keys are present only if there is actually an error to report.
@@ -90,20 +96,11 @@ class Upload:
             }
         return errors
 
-    def _get_plugin_errors(self):
-        plugin_path = self.plugin_directory
-        if not plugin_path:
-            return None
-        errors = defaultdict(list)
-        for metadata_path in self.effective_tsv_paths.keys():
-            try:
-                for k, v in run_plugin_validators_iter(metadata_path,
-                                                       plugin_path):
-                    errors[k].append(v)
-            except PluginValidatorError as e:
-                # We are ok with just returning a single error, rather than all.
-                errors['Unexpected Plugin Error'] = str(e)
-        return dict(errors)  # get rid of defaultdict
+    ###################################
+    #
+    # Three top-level private methods:
+    #
+    ###################################
 
     def _get_tsv_errors(self):
         if not self.effective_tsv_paths:
@@ -123,9 +120,9 @@ class Upload:
             schema_name = schema_version.schema_name
 
             single_tsv_internal_errors = \
-                self._get_assay_internal_errors(schema_name, path)
+                self.__get_assay_internal_errors(schema_name, path)
             single_tsv_external_errors = \
-                self._get_assay_reference_errors(schema_name, path)
+                self.__get_assay_reference_errors(schema_name, path)
 
             single_tsv_errors = {}
             if single_tsv_internal_errors:
@@ -136,7 +133,41 @@ class Upload:
                 errors[f'{path} (as {schema_name})'] = single_tsv_errors
         return errors
 
-    def _get_ref_errors(self, ref_type, path, assay_type):
+    def _get_reference_errors(self):
+        errors = {}
+        no_ref_errors = self.__get_no_ref_errors()
+        try:
+            multi_ref_errors = self.__get_multi_ref_errors()
+        except UnicodeDecodeError as e:
+            return get_context_of_decode_error(e)
+        if no_ref_errors:
+            errors['No References'] = no_ref_errors
+        if multi_ref_errors:
+            errors['Multiple References'] = multi_ref_errors
+        return errors
+
+    def _get_plugin_errors(self):
+        plugin_path = self.plugin_directory
+        if not plugin_path:
+            return None
+        errors = defaultdict(list)
+        for metadata_path in self.effective_tsv_paths.keys():
+            try:
+                for k, v in run_plugin_validators_iter(metadata_path,
+                                                       plugin_path):
+                    errors[k].append(v)
+            except PluginValidatorError as e:
+                # We are ok with just returning a single error, rather than all.
+                errors['Unexpected Plugin Error'] = str(e)
+        return dict(errors)  # get rid of defaultdict
+
+    ##############################
+    #
+    # Supporting private methods:
+    #
+    ##############################
+
+    def __get_ref_errors(self, ref_type, path, assay_type):
         if ref_type == 'data':
             return get_data_dir_errors(
                 assay_type, path, dataset_ignore_globs=self.dataset_ignore_globs)
@@ -145,13 +176,13 @@ class Upload:
                 schema_name=ref_type, tsv_path=path,
                 offline=self.offline, encoding=self.encoding)
 
-    def _get_assay_internal_errors(self, assay_type, path):
+    def __get_assay_internal_errors(self, assay_type, path):
         return get_tsv_errors(
             schema_name=assay_type, tsv_path=path,
             offline=self.offline, encoding=self.encoding,
             optional_fields=self.optional_fields)
 
-    def _get_assay_reference_errors(self, assay_type, path):
+    def __get_assay_reference_errors(self, assay_type, path):
         try:
             rows = dict_reader_wrapper(path, self.encoding)
         except UnicodeDecodeError as e:
@@ -171,31 +202,18 @@ class Upload:
                 if not row.get(field):
                     continue
                 path = self.directory_path / row[field]
-                ref_errors = self._get_ref_errors(ref, path, assay_type)
+                ref_errors = self.__get_ref_errors(ref, path, assay_type)
                 if ref_errors:
                     errors[f'{row_number}, {ref} {path}'] = ref_errors
 
         return errors
 
-    def _get_reference_errors(self):
-        errors = {}
-        no_ref_errors = self._get_no_ref_errors()
-        try:
-            multi_ref_errors = self._get_multi_ref_errors()
-        except UnicodeDecodeError as e:
-            return get_context_of_decode_error(e)
-        if no_ref_errors:
-            errors['No References'] = no_ref_errors
-        if multi_ref_errors:
-            errors['Multiple References'] = multi_ref_errors
-        return errors
-
-    def _get_no_ref_errors(self):
+    def __get_no_ref_errors(self):
         if not self.directory_path:
             return {}
-        referenced_data_paths = set(self._get_data_references().keys()) \
-            | set(self._get_contributors_references().keys()) \
-            | set(self._get_antibodies_references().keys())
+        referenced_data_paths = set(self.__get_data_references().keys()) \
+            | set(self.__get_contributors_references().keys()) \
+            | set(self.__get_antibodies_references().keys())
         non_metadata_paths = {
             path.name for path in self.directory_path.iterdir()
             if not path.name.endswith(TSV_SUFFIX)
@@ -207,24 +225,24 @@ class Upload:
         unreferenced_paths = non_metadata_paths - referenced_data_paths
         return [str(path) for path in unreferenced_paths]
 
-    def _get_multi_ref_errors(self):
+    def __get_multi_ref_errors(self):
         errors = {}
-        data_references = self._get_data_references()
+        data_references = self.__get_data_references()
         for path, references in data_references.items():
             if len(references) > 1:
                 errors[path] = references
         return errors
 
-    def _get_data_references(self):
-        return self._get_references('data_path')
+    def __get_data_references(self):
+        return self.__get_references('data_path')
 
-    def _get_antibodies_references(self):
-        return self._get_references('antibodies_path')
+    def __get_antibodies_references(self):
+        return self.__get_references('antibodies_path')
 
-    def _get_contributors_references(self):
-        return self._get_references('contributors_path')
+    def __get_contributors_references(self):
+        return self.__get_references('contributors_path')
 
-    def _get_references(self, col_name):
+    def __get_references(self, col_name):
         references = defaultdict(list)
         for tsv_path in self.effective_tsv_paths.keys():
             for i, row in enumerate(dict_reader_wrapper(tsv_path, self.encoding)):

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -98,7 +98,7 @@ class Upload:
 
     ###################################
     #
-    # Three top-level private methods:
+    # Top-level private methods:
     #
     ###################################
 
@@ -120,7 +120,7 @@ class Upload:
             schema_name = schema_version.schema_name
 
             single_tsv_internal_errors = \
-                self.__get_assay_internal_errors(schema_name, path)
+                self.__get_assay_tsv_errors(schema_name, path)
             single_tsv_external_errors = \
                 self.__get_assay_reference_errors(schema_name, path)
 
@@ -176,7 +176,7 @@ class Upload:
                 schema_name=ref_type, tsv_path=path,
                 offline=self.offline, encoding=self.encoding)
 
-    def __get_assay_internal_errors(self, assay_type, path):
+    def __get_assay_tsv_errors(self, assay_type, path):
         return get_tsv_errors(
             schema_name=assay_type, tsv_path=path,
             offline=self.offline, encoding=self.encoding,


### PR DESCRIPTION
Reorder the methods, and add some headers for clarity. I know that that `__` has particular semantics in python, but thought it might be useful to distinguish the private methods from the private-private methods? Not sure it's the best idea.

Extends #844... but separate PR to keep that one readable.