### PR TITLE
Added description_md for CEMS

### DIFF
--- a/docs/cems/v1.yaml
+++ b/docs/cems/v1.yaml
@@ -1,5 +1,6 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
+description_md: This schema is for capillary electrophoresis - mass spectrometry (CEMS).
 fields:
 - constraints:
     enum:


### PR DESCRIPTION
"description_md: This schema is for capillary electrophoresis - mass spectrometry (CEMS)."