### PR TITLE
Update the flowchart to reflect the roles of Bill and PK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.13 - in progress
+- Update the flowchart to reflect the roles of Bill and PK.
 - Hotfix on CellDive directory to reflect changes to dataset.
 - Updated CellDive directory structure.
 - Updated CODEX directory structure.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Data upload to HuBMAP is composed of discrete phases:
 - Restructuring
 - Re-re-validation and pipeline runs
 
-[![Upload process](https://docs.google.com/drawings/d/e/2PACX-1vScOVTJCQjaHj0oiVuvPxuQDNXFCtI-CGTTOm-kSPji9DehMxRIaWg98qKAkkvwSWn5d2TuL1z4mIyh/pub?w=1000)](https://docs.google.com/drawings/d/11DLkPe_mfC3kh69HCYqCx5MAVTTkYOXqVjyFY85jMLQ/edit)
+[![Upload process](https://docs.google.com/drawings/d/e/2PACX-1vSlMUKk0QU1bboxbT3x6gEMRawZDjZH_PWma2ZKVsnqlIDaCg3OFKq2zQg9dW_2ty8U3Z4UEENhUMvR/pub?w=1000)](https://docs.google.com/drawings/d/1fDhORYm8DYnCnbvpIrMMN0OxFQakHir_Ss071q2ySNc/edit)
 
 Uploads are based on directories containing at a minimum:
 - one or more `*-metadata.tsv` files.


### PR DESCRIPTION
Some discussion this morning about why/how particular datasets had gotten published made me realize that the end of the flowchart hasn't been accurate. This adds one additional step to the diagram:
> **PM** gathers approvals;
> **PSC** publishes

It also 
- adds these two roles to the key in the lower right.
- cleans up the arrows at the bottom of the left column.

My understanding is that we're still waiting for the discussion about pinning down who _precisely_ needs to approve before publication, so more tweaks might come out of that, but I think the two questions can be considered separately. (Matt and Ilan have had an ad-hoc role in approval, but I don't believe they are a permanent part of the approval process for each dataset going forward.)