### PR TITLE
Update lc_temp_value.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.13 - in progress
+- Update the lcms schema field "lc_temp_value" optional.
 - Hit a different URL for ORCID, that will not give us soft 404s.
 - In bash scripts, make python3 explicit.
 - Update the flowchart to reflect the roles of Bill and PK.

--- a/docs/lcms/index.md
+++ b/docs/lcms/index.md
@@ -396,12 +396,12 @@ units for LC column length (typically cm) Leave blank if not applicable.
 
 <a name="lc_temp_value"></a>
 ##### [`lc_temp_value`](#lc_temp_value)
-LC temperature.
+LC temperature. Leave blank if not applicable.
 
 | constraint | value |
 | --- | --- |
 | type | `number` |
-| required | `True` |
+| required | `False` |
 
 <a name="lc_temp_unit"></a>
 ##### [`lc_temp_unit`](#lc_temp_unit)
@@ -864,12 +864,12 @@ units for LC column length (typically cm) Leave blank if not applicable.
 
 <a name="lc_temp_value"></a>
 ##### [`lc_temp_value`](#lc_temp_value)
-LC temperature.
+LC temperature. Leave blank if not applicable.
 
 | constraint | value |
 | --- | --- |
 | type | `number` |
-| required | `True` |
+| required | `False` |
 
 <a name="lc_temp_unit"></a>
 ##### [`lc_temp_unit`](#lc_temp_unit)
@@ -1252,12 +1252,12 @@ units for LC column length (typically cm) Leave blank if not applicable.
 
 <a name="lc_temp_value"></a>
 ##### [`lc_temp_value`](#lc_temp_value)
-LC temperature.
+LC temperature. Leave blank if not applicable.
 
 | constraint | value |
 | --- | --- |
 | type | `number` |
-| required | `True` |
+| required | `False` |
 
 <a name="lc_temp_unit"></a>
 ##### [`lc_temp_unit`](#lc_temp_unit)

--- a/docs/lcms/v0.yaml
+++ b/docs/lcms/v0.yaml
@@ -264,7 +264,7 @@ fields:
   description: units for LC column length (typically cm)
   name: lc_length_unit
 - constraints:
-    required: true
+    required: false
   custom_constraints:
     forbid_na: true
     sequence_limit: 3

--- a/docs/lcms/v1.yaml
+++ b/docs/lcms/v1.yaml
@@ -280,7 +280,7 @@ fields:
   description: units for LC column length (typically cm)
   name: lc_length_unit
 - constraints:
-    required: true
+    required: false
   custom_constraints:
     forbid_na: true
     sequence_limit: 3

--- a/docs/lcms/v2.yaml
+++ b/docs/lcms/v2.yaml
@@ -326,7 +326,7 @@ fields:
   description: units for LC column length (typically cm)
   name: lc_length_unit
 - constraints:
-    required: true
+    required: false
   custom_constraints:
     forbid_na: true
     sequence_limit: 3

--- a/src/ingest_validation_tools/table-schemas/includes/fields/lc_temp_value.yaml
+++ b/src/ingest_validation_tools/table-schemas/includes/fields/lc_temp_value.yaml
@@ -1,2 +1,4 @@
 - name: lc_temp_value
   description: LC temperature
+  constraints:
+    required: False


### PR DESCRIPTION
lc_temp may not be applicable in certain cases (no heating involved). Make this field optional, as is the corresponding lc_temp_unit field.