### PR TITLE
Add MALDI-IMS-neg and MALDI-IMS-pos to ims table schemata

### DIFF
--- a/src/ingest_validation_tools/table-schemas/assays/ims-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v0.yaml
@@ -9,6 +9,8 @@ fields:
   constraints:
     enum:
       - MALDI-IMS
+      - MALDI-IMS-pos
+      - MALDI-IMS-neg
 - name: analyte_class
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/ims-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v1.yaml
@@ -9,6 +9,8 @@ fields:
   constraints:
     enum:
       - MALDI-IMS
+      - MALDI-IMS-pos
+      - MALDI-IMS-neg
 - name: analyte_class
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
@@ -16,6 +16,8 @@ fields:
   constraints:
     enum:
       - MALDI-IMS
+      - MALDI-IMS-pos
+      - MALDI-IMS-neg
       - SIMS-IMS
       - NanoDESI
       - DESI


### PR DESCRIPTION
 The new Vanderbilt MALDI-IMS datasets are currently not runnable because the official assay type names are MALDI-IMS-pos and MALDI-IMS-neg while the assay_type constraints in ingest-validation-tools/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml (and earlier versions) is just MALDI-IMS .  This PR resolves this conflict by adding MALDI-IMS-pos and MALDI-IMS-neg to the table-schemas.