### PR TITLE
example directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.13 - in progress
+- Script to populate directory based on examples.
 - Updated LC-MS directory structure schema.
 - Work around mypy importlib type hinting problem.
 - Longer assay description for LCMS, and supporting machinery.

--- a/script-docs/README-generate_example_directory.py.md
+++ b/script-docs/README-generate_example_directory.py.md
@@ -1,0 +1,10 @@
+```text
+usage: generate_example_directory.py [-h] --dir_schema DIR_SCHEMA --target
+                                     TARGET
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --dir_schema DIR_SCHEMA
+                        Directory schema file
+  --target TARGET       Target directory to populate
+```

--- a/src/generate_example_directory.py
+++ b/src/generate_example_directory.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+from pathlib import Path
+
+from yaml import safe_load
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--dir_schema',
+        type=Path,
+        required=True,
+        help='Directory schema file')
+    parser.add_argument(
+        '--target',
+        type=Path,
+        required=True,
+        help='Target directory to populate')
+    args = parser.parse_args()
+
+    schema = safe_load(args.dir_schema.read_text())
+    for entry in schema:
+        if 'example' not in entry:
+            print(f'No example for {entry["pattern"]}')
+            continue
+        new_path = args.target / entry['example']
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        new_path.touch()
+        print(f'Created {new_path}')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())  # pragma: no cover


### PR DESCRIPTION
Fix #952. I don't care strongly about the basic issue one way or another, but if it's going to be done, this is the way it should be done: We should build from the examples that are already available for some assays, instead of creating a new, inconsistent system. (But I'm ok with this not going ahead at all, too.)

```
$ src/generate_example_directory.py --dir_schema src/ingest_validation_tools/directory-schemas/codex.yaml --target /tmp/foo/bar
Created /tmp/foo/bar/NAV.tif
Created /tmp/foo/bar/summary.pdf
No example for (raw|src_[^/]*)/exposure_times\.txt
Created /tmp/foo/bar/raw/reg_00.png
No example for (raw|src_[^/]*)/[Ee]xperiment\.json
No example for processed/HandE\.tif
No example for processed/HandE_RGB\.tif
No example for processed/HandE_RGB_thumbnail.jpg
No example for (src_[^/]*|drv_[^/]*|extras)/[sS]egmentation\.json
No example for (raw|processed)/config\.txt
No example for (raw|processed)/config\.txt|(src_[^/]*|drv_[^/]*|extras)/[sS]egmentation\.json
No example for src_[^/]+/channelnames_report\.csv
No example for (raw|src_.*)/[cC]yc.*_reg.*/.*_Z.*_CH.*\.tif
No example for src_.*/cyc.*_reg.*_.*/.*\.gci
No example for (raw|src_.*)/channel[Nn]ames\.txt
No example for (raw|src_.*)/.*
No example for (processed|drv_[^/]*)/.*

$ tree /tmp/foo/bar
/tmp/foo/bar
├── NAV.tif
├── raw
│   └── reg_00.png
└── summary.pdf
```