### PR TITLE
new vs: Add dms field to lc-ms

### DIFF
--- a/src/ingest_validation_tools/table-schemas/assays/lcms-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lcms-v2.yaml
@@ -45,8 +45,6 @@ fields:
 - name: dms
   description: Was differential mobility spectrometry used in this assay?
   type: boolean
-  constraints:
-    required: TRUE
 - name: ms_source
   description: The ion source type used for surface sampling.
   constraints:


### PR DESCRIPTION
Some investigators use differential mobility spectrometry in an lc-ms assay. This field is required & takes a boolean.

NOTE: Please add this field in addition to the "label_name" field to the "labeling" includes yaml #977

@mccalluc please regenerate the doc with these 2 additional fields in a new version of LC-MS