### PR TITLE
fix regex in lcms directory schema

### DIFF
--- a/src/ingest_validation_tools/directory-schemas/lcms.yaml
+++ b/src/ingest_validation_tools/directory-schemas/lcms.yaml
@@ -1,16 +1,16 @@
 -
-  pattern: 'raw_data/*\.(raw|mzML)'
+  pattern: 'raw_data/.*\.(raw|mzML)'
   description: 'Raw mass spectrometry data from an assay of LC-MS, MS, LC-MS Bottom-Up, MS Bottom-Up, LC-MS Top-Down, or MS Top-Down that describes an analyte class of protein, metabolites, lipids, peptides, phosphopeptides, or glycans.'
   required: True
 -
-  pattern: 'ID_search_results/*\.(txt|csv)'
+  pattern: 'ID_search_results/.*\.(txt|csv)'
   description: 'Identification results. Annotated data describing (qualitative or quantitative) the proteins, metabolites, lipids, peptides, phosphopeptides, or glycans identified from the corresponding raw data.'
   required: True
 -
-  pattern: 'ID_metadata/*\.xml'
+  pattern: 'ID_metadata/.*\.xml'
   description: 'Identification search parameters / metadata. Software settings used during the analyte identification process (e.g., from MaxQuant or Proteome Discoverer).'
   required: False
 -
-  pattern: 'QC_results/*\.(xml|txt|html|pdf|log|yaml)'
+  pattern: 'QC_results/.*\.(xml|txt|html|pdf|log|yaml)'
   description: 'Output file resulting from QC analysis. A list of metrics with the score of the current dataset that shows the quality of data collection.'
   required: False


### PR DESCRIPTION
There is a regex error in the lcms directory schema (described by @mccalluc in #939) that makes it fail. This fixes it uses the suggestions from @mccalluc. May create a conflict with #981. 

This resolves #939.