### PR TITLE
Added WGS directory structure schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.13 - in progress
+- Added WGS directory structure schema.
 - Cleaned up LC-MS directory structure schema.
 - Added links to examples in the portal for 5 assays.
 - Make LC fields optional.

--- a/docs/wgs/index.md
+++ b/docs/wgs/index.md
@@ -17,7 +17,7 @@ Related files:
 
 | pattern | required? | description |
 | --- | --- | --- |
-| `TODO` | ✓ | Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/455 |
+| `[^/]+\.fastq\.gz` | ✓ | Compressed FastQ file |
 | `extras/.*` |  | Free-form descriptive information supplied by the TMC |
 | `extras/thumbnail\.(png\|jpg)` |  | Optional thumbnail image which may be shown in search interface |
 

--- a/src/ingest_validation_tools/directory-schemas/wgs.yaml
+++ b/src/ingest_validation_tools/directory-schemas/wgs.yaml
@@ -1,4 +1,0 @@
--
-  pattern: 'TODO'
-  description: 'Directory structure not yet specified. https://github.com/hubmapconsortium/ingest-validation-tools/issues/455'
-

--- a/src/ingest_validation_tools/directory-schemas/wgs.yaml
+++ b/src/ingest_validation_tools/directory-schemas/wgs.yaml
@@ -1,0 +1,1 @@
+fastq.yaml


### PR DESCRIPTION
The directory structure for the whole genome sequence assay type is nothing but a link to `fastq.yaml`. 

From my understanding, this should suffice for now.