### PR TITLE
Mccalluc/handle section headers differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.14 - in progress
+- Headers are no longer properties of fields.
 - Remove mention of `extras/thumbnail.jpg`.
 - Add release date to schema.
 - Add UMI fields to scrnaseq schema.

--- a/docs/af/v0.yaml
+++ b/docs/af/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/af
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -112,6 +112,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -120,7 +121,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/af/v1.yaml
+++ b/docs/af/v1.yaml
@@ -4,6 +4,7 @@ description_md: This schema is for autofluorescence (AF). For an example of an A
   and click the Globus link.
 doc_url: https://portal.hubmapconsortium.org/docs/assays/af
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -12,7 +13,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -131,6 +131,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -139,7 +140,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/bulkatacseq/v0.yaml
+++ b/docs/bulkatacseq/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -114,6 +114,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -122,7 +123,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/bulkatacseq/v1.yaml
+++ b/docs/bulkatacseq/v1.yaml
@@ -3,6 +3,7 @@ description_md: This schema is for Assay for Transposase-Accessible Chromatin by
   (ATACseq)of bulk sample.
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -11,7 +12,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -132,6 +132,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -140,7 +141,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/bulkrnaseq/v0.yaml
+++ b/docs/bulkrnaseq/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -114,6 +114,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -122,7 +123,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/bulkrnaseq/v1.yaml
+++ b/docs/bulkrnaseq/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -130,6 +130,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -138,7 +139,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/celldive/v0.yaml
+++ b/docs/celldive/v0.yaml
@@ -7,6 +7,7 @@ description_md: 'CellDIVE uploads require metadata on the antibodies used in the
   The other fields function the same way for all assays using antibodies. For more
   information, see the [Antibodies TSV documentation](../antibodies).'
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -14,7 +15,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -120,6 +120,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -128,7 +129,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/celldive/v1.yaml
+++ b/docs/celldive/v1.yaml
@@ -7,6 +7,7 @@ description_md: 'CellDIVE uploads require metadata on the antibodies used in the
   The other fields function the same way for all assays using antibodies. For more
   information, see the [Antibodies TSV documentation](../antibodies).'
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -15,7 +16,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -136,6 +136,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -144,7 +145,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/cems/v1.yaml
+++ b/docs/cems/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -135,6 +135,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -143,7 +144,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/codex/v0.yaml
+++ b/docs/codex/v0.yaml
@@ -10,6 +10,7 @@ description_md: 'CODEX uploads require metadata on the antibodies used in the as
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/codex
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -17,7 +18,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -123,6 +123,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     enum:
     - Keyence
@@ -134,7 +135,6 @@ fields:
   description: An acquisition_instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     enum:
@@ -215,6 +215,7 @@ fields:
     units_for: resolution_z_value
   description: The unit of incremental distance between image slices.
   name: resolution_z_unit
+- Level 3
 - constraints:
     enum:
     - CODEX
@@ -224,7 +225,6 @@ fields:
     sequence_limit: 3
   description: The manufacturer of the instrument used to prepare the sample for the
     assay.
-  heading: Level 3
   name: preparation_instrument_vendor
 - constraints:
     enum:

--- a/docs/codex/v1.yaml
+++ b/docs/codex/v1.yaml
@@ -13,6 +13,7 @@ description_md: 'This schema is for CO-Detection by indEXing (CODEX). CODEX uplo
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/codex
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -21,7 +22,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -142,6 +142,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     enum:
     - Keyence
@@ -153,7 +154,6 @@ fields:
   description: An acquisition_instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     enum:

--- a/docs/gcms/v1.yaml
+++ b/docs/gcms/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 description_md: This schema is for gas chromatography - mass spectrophotometry (GCMS).
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -131,6 +131,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -139,7 +140,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/imc/v0.yaml
+++ b/docs/imc/v0.yaml
@@ -7,6 +7,7 @@ description_md: 'IMC uploads require metadata on the antibodies used in the assa
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/imc
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -14,7 +15,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -120,6 +120,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -128,7 +129,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/imc/v1.yaml
+++ b/docs/imc/v1.yaml
@@ -7,6 +7,7 @@ description_md: 'This schema is for imaging mass cytometry (IMC). IMC uploads re
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/imc
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -15,7 +16,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -136,6 +136,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -144,7 +145,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/imc3d/v0.yaml
+++ b/docs/imc3d/v0.yaml
@@ -7,6 +7,7 @@ description_md: '3D IMC uploads require metadata on the antibodies used in the a
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/imc
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -14,7 +15,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -120,6 +120,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -128,7 +129,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/imc3d/v1.yaml
+++ b/docs/imc3d/v1.yaml
@@ -8,6 +8,7 @@ description_md: 'This schema is for 3 dimensional imaging mass cytometry (IMC 3D
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/imc
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -16,7 +17,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -137,6 +137,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -145,7 +146,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/ims/v0.yaml
+++ b/docs/ims/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -116,6 +116,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -124,7 +125,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/ims/v1.yaml
+++ b/docs/ims/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -132,6 +132,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -140,7 +141,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/ims/v2.yaml
+++ b/docs/ims/v2.yaml
@@ -2,6 +2,7 @@
 description_md: This schema is for imaging mass spectrometry (IMS).
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '2'
@@ -10,7 +11,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -139,6 +139,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -147,7 +148,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/lcms/v0.yaml
+++ b/docs/lcms/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lcms
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -118,6 +118,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -126,7 +127,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/lcms/v1.yaml
+++ b/docs/lcms/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lcms
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -134,6 +134,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -142,7 +143,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/lcms/v2.yaml
+++ b/docs/lcms/v2.yaml
@@ -8,6 +8,7 @@ description_md: This schema is for liquid chromatography mass spectrometry (LCMS
   and click the Globus link.
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lcms
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '2'
@@ -16,7 +17,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -150,6 +150,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -158,7 +159,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/lcms/v3.yaml
+++ b/docs/lcms/v3.yaml
@@ -10,6 +10,7 @@ description_md: 'This schema is for liquid chromatography mass spectrometry (LCM
   polarity option.'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lcms
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '3'
@@ -18,7 +19,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -152,6 +152,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -160,7 +161,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/lightsheet/v0.yaml
+++ b/docs/lightsheet/v0.yaml
@@ -7,6 +7,7 @@ description_md: 'Lightsheet uploads require metadata on the antibodies used in t
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lightsheet
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -14,7 +15,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -120,6 +120,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -128,7 +129,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/lightsheet/v1.yaml
+++ b/docs/lightsheet/v1.yaml
@@ -7,6 +7,7 @@ description_md: 'Lightsheet uploads require metadata on the antibodies used in t
   information, see the [Antibodies TSV documentation](../antibodies).'
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lightsheet
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -15,7 +16,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -136,6 +136,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -144,7 +145,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/lightsheet/v2.yaml
+++ b/docs/lightsheet/v2.yaml
@@ -11,6 +11,7 @@ description_md: "Lightsheet uploads require metadata on the antibodies used in t
   \ information, see the [Antibodies TSV documentation](../antibodies)."
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lightsheet
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '2'
@@ -19,7 +20,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -140,6 +140,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -148,7 +149,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/mibi/v1.yaml
+++ b/docs/mibi/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 description_md: This schema is for Multiplex Ion Beam Imaging (MIBI).
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true

--- a/docs/mxif/v0.yaml
+++ b/docs/mxif/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/mxif
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -114,6 +114,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -122,7 +123,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/mxif/v1.yaml
+++ b/docs/mxif/v1.yaml
@@ -2,6 +2,7 @@
 description_md: This schema is for multiplex immunofluorescence microscopy (MxIF).
 doc_url: https://portal.hubmapconsortium.org/docs/assays/mxif
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -10,7 +11,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -131,6 +131,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -139,7 +140,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/nano/v0.yaml
+++ b/docs/nano/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 deprecated: true
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -115,6 +115,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -123,7 +124,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/nano/v1.yaml
+++ b/docs/nano/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 deprecated: true
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -131,6 +131,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -139,7 +140,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/sample/v0.yaml
+++ b/docs/sample/v0.yaml
@@ -1,5 +1,6 @@
 # Generated YAML: PRs should not start here!
 fields:
+- IDs
 - constraints:
     pattern: ([A-Z]+[0-9]+)-[A-Z]{2}\d*(-\d+)+(_\d+)?
     required: true
@@ -7,9 +8,9 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: (No description for this field was supplied.)
-  heading: IDs
   name: sample_id
   type: string
+- Donor
 - constraints:
     enum:
     - living
@@ -19,7 +20,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Identify the vital state of the donor.
-  heading: Donor
   name: vital_state
 - constraints:
     enum:
@@ -38,6 +38,7 @@ fields:
     \ of organ donation, a sample is collected.  In this scenario, the subject is\
     \ deemed \u201Crelatively healthy.\u201D"
   name: health_status
+- Medical Procedure
 - constraints:
     enum:
     - healthy
@@ -47,7 +48,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Health status of the organ at the time of sample recovery.
-  heading: Medical Procedure
   name: organ_condition
 - constraints:
     required: true
@@ -120,6 +120,7 @@ fields:
     units_for: cold_ischemia_time_value
   description: Time unit
   name: cold_ischemia_time_unit
+- Biospecimen
 - constraints:
     enum:
     - Liquid Nitrogen
@@ -133,7 +134,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: The temperature of the medium during the preservation process.
-  heading: Biospecimen
   name: specimen_preservation_temperature
 - constraints:
     required: false

--- a/docs/scatacseq/v0.yaml
+++ b/docs/scatacseq/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -117,6 +117,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -125,7 +126,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/scatacseq/v1.yaml
+++ b/docs/scatacseq/v1.yaml
@@ -3,6 +3,7 @@ description_md: This schema is for the single cell Assay for Transposase Accessi
   Chromatin by sequencing (scATACseq).
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -11,7 +12,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -135,6 +135,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -143,7 +144,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/scrnaseq-hca/v0.yaml
+++ b/docs/scrnaseq-hca/v0.yaml
@@ -11,12 +11,12 @@ fields:
   description: External source (outside of HuBMAP) of the project, eg. HCA (The Human
     Cell Atlas Consortium).
   name: source_project
+- Shared by all types
 - constraints:
     required: false
   custom_constraints:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -126,6 +126,7 @@ fields:
     protein.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -134,7 +135,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/scrnaseq/v0.yaml
+++ b/docs/scrnaseq/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -118,6 +118,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -126,7 +127,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/scrnaseq/v1.yaml
+++ b/docs/scrnaseq/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -134,6 +134,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -142,7 +143,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/scrnaseq/v2.yaml
+++ b/docs/scrnaseq/v2.yaml
@@ -2,6 +2,7 @@
 description_md: This schema is for single cell RNA sequencing (scRNAseq).
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '2'
@@ -10,7 +11,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -136,6 +136,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -144,7 +145,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/scrnaseq/v3.yaml
+++ b/docs/scrnaseq/v3.yaml
@@ -3,6 +3,7 @@ description_md: This schema is for single cell RNA sequencing (scRNAseq). v3 add
   `umi_*` fields.
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '3'
@@ -11,7 +12,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -137,6 +137,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -145,7 +146,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/seqfish/v0.yaml
+++ b/docs/seqfish/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/seqfish
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -114,6 +114,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -122,7 +123,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/seqfish/v1.yaml
+++ b/docs/seqfish/v1.yaml
@@ -3,6 +3,7 @@ description_md: This schema is for spatial sequencing by fluorescence in situ hy
   (seqFISH).
 doc_url: https://portal.hubmapconsortium.org/docs/assays/seqfish
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -11,7 +12,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -132,6 +132,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -140,7 +141,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/slideseq/v0.yaml
+++ b/docs/slideseq/v0.yaml
@@ -1,5 +1,6 @@
 # Generated YAML: PRs should not start here!
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -7,7 +8,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -113,6 +113,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -121,7 +122,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/slideseq/v1.yaml
+++ b/docs/slideseq/v1.yaml
@@ -1,5 +1,6 @@
 # Generated YAML: PRs should not start here!
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -129,6 +129,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -137,7 +138,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/stained/v0.yaml
+++ b/docs/stained/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/pas
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -112,6 +112,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -120,7 +121,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/stained/v1.yaml
+++ b/docs/stained/v1.yaml
@@ -5,6 +5,7 @@ description_md: "This schema is for microscopy of tissue treated with periodic a
   \ and click the Globus link."
 doc_url: https://portal.hubmapconsortium.org/docs/assays/pas
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -13,7 +14,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -132,6 +132,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -140,7 +141,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/wgs/v0.yaml
+++ b/docs/wgs/v0.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/wgs
 fields:
+- Shared by all types
 - constraints:
     pattern: '[A-Z]+[0-9]+'
     required: true
@@ -8,7 +9,6 @@ fields:
     forbid_na: true
   description: HuBMAP Display ID of the donor of the assayed tissue.
   example: ABC123
-  heading: Shared by all types
   name: donor_id
   type: string
 - constraints:
@@ -114,6 +114,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -122,7 +123,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/docs/wgs/v1.yaml
+++ b/docs/wgs/v1.yaml
@@ -1,6 +1,7 @@
 # Generated YAML: PRs should not start here!
 doc_url: https://portal.hubmapconsortium.org/docs/assays/wgs
 fields:
+- Shared by all types
 - constraints:
     enum:
     - '1'
@@ -9,7 +10,6 @@ fields:
     forbid_na: true
     sequence_limit: 3
   description: Version of the schema to use when validating this metadata.
-  heading: Shared by all types
   name: version
 - constraints:
     required: true
@@ -130,6 +130,7 @@ fields:
     detection/measurement by the assay.
   name: is_targeted
   type: boolean
+- Unique to this type
 - constraints:
     required: true
   custom_constraints:
@@ -138,7 +139,6 @@ fields:
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
   name: acquisition_instrument_vendor
 - constraints:
     required: true

--- a/src/generate_docs.py
+++ b/src/generate_docs.py
@@ -9,7 +9,7 @@ from tableschema_to_template.create_xlsx import create_xlsx
 
 from ingest_validation_tools.schema_loader import (
     dict_schema_versions, get_table_schema, get_other_schema, get_directory_schema,
-    get_pipeline_infos, get_is_assay, enum_maps_to_lists)
+    get_pipeline_infos, get_is_assay, enum_maps_to_lists, get_fields_wo_headers)
 from ingest_validation_tools.docs_utils import (
     get_tsv_name, get_xlsx_name,
     generate_template_tsv, generate_readme_md)
@@ -60,7 +60,7 @@ def main():
     # YAML:
     for v in versions:
         schema = table_schemas[v]
-        first_field = [f for f in schema['fields'] if not isinstance(f, str)][0]
+        first_field = get_fields_wo_headers(schema)[0]
         if first_field['name'] == 'version':
             assert first_field['constraints']['enum'] == [v], \
                 f'Wrong version constraint in {args.type}-v{v}.yaml'
@@ -74,7 +74,7 @@ def main():
     # Data entry templates:
     max_schema = enum_maps_to_lists(table_schemas[max_version],
                                     add_none_of_the_above=True, add_suggested=True)
-    max_schema['fields'] = [f for f in max_schema['fields'] if not isinstance(f, str)]
+    max_schema['fields'] = get_fields_wo_headers(max_schema)
     with open(Path(args.target) / get_tsv_name(args.type, is_assay=is_assay), 'w') as f:
         f.write(generate_template_tsv(max_schema))
     create_xlsx(

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -3,7 +3,7 @@ from string import Template
 from pathlib import Path
 import html
 
-from ingest_validation_tools.schema_loader import get_field_enum
+from ingest_validation_tools.schema_loader import get_field_enum, get_fields_wo_headers
 
 
 def get_tsv_name(type, is_assay=True):
@@ -26,7 +26,7 @@ def generate_template_tsv(table_schema):
     'fake\\na / b / c'
     '''
 
-    names = [field['name'] for field in table_schema['fields'] if not isinstance(field, str)]
+    names = [field['name'] for field in get_fields_wo_headers(table_schema)]
     header_row = '\t'.join(names)
 
     enums = [

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -26,7 +26,7 @@ def generate_template_tsv(table_schema):
     'fake\\na / b / c'
     '''
 
-    names = [field['name'] for field in table_schema['fields']]
+    names = [field['name'] for field in table_schema['fields'] if not isinstance(field, str)]
     header_row = '\t'.join(names)
 
     enums = [
@@ -169,11 +169,13 @@ def generate_readme_md(
 
 def _make_fields_md(table_schema, title, is_open=False):
     '''
-    >>> schema = {'fields': [{
-    ...   'heading': 'A head',
-    ...   'name': 'a_name',
-    ...   'description': 'A description'
-    ... }]}
+    >>> schema = {'fields': [
+    ...   'A head',
+    ...   {
+    ...     'name': 'a_name',
+    ...     'description': 'A description'
+    ...   }
+    ... ]}
     >>> print(_clean(_make_fields_md(schema, 'A title')))
     <details markdown="1" ><summary><b>A title</b></summary>
     ### A head
@@ -192,8 +194,9 @@ def _make_fields_md(table_schema, title, is_open=False):
 
     fields_md_list = []
     for field in table_schema['fields']:
-        if 'heading' in field:
-            fields_md_list.append(f"### {field['heading']}")
+        if isinstance(field, str):
+            fields_md_list.append(f"### {field}")
+            continue
         table_md = _make_constraints_table(field)
         name = field['name']
         fields_md_list.append('\n'.join([

--- a/src/ingest_validation_tools/schema_loader.py
+++ b/src/ingest_validation_tools/schema_loader.py
@@ -24,10 +24,15 @@ class PreflightError(Exception):
 SchemaVersion = namedtuple('SchemaVersion', ['schema_name', 'version'])
 
 
+def get_fields_wo_headers(schema):
+    return [field for field in schema['fields'] if not isinstance(field, str)]
+
+
 def get_field_enum(field_name, schema):
+    fields_wo_headers = get_fields_wo_headers(schema)
     fields = [
-        field for field in schema['fields']
-        if not isinstance(field, str) and field['name'] == field_name
+        field for field in fields_wo_headers
+        if field['name'] == field_name
     ]
     if not fields:
         return []
@@ -162,7 +167,7 @@ def get_other_schema(schema_name, version, offline=None, keep_headers=False):
     schema = load_yaml(
         _table_schemas_path / 'others' /
         _get_schema_filename(schema_name, version))
-    fields_wo_headers = [field for field in schema['fields'] if not isinstance(field, str)]
+    fields_wo_headers = get_fields_wo_headers(schema)
     if not keep_headers:
         schema['fields'] = fields_wo_headers
 
@@ -183,7 +188,7 @@ def get_table_schema(schema_name, version, optional_fields=[], offline=None, kee
     schema = load_yaml(
         _table_schemas_path / 'assays' /
         _get_schema_filename(schema_name, version))
-    fields_wo_headers = [field for field in schema['fields'] if not isinstance(field, str)]
+    fields_wo_headers = get_fields_wo_headers(schema)
     if not keep_headers:
         schema['fields'] = fields_wo_headers
 

--- a/src/ingest_validation_tools/schema_loader.py
+++ b/src/ingest_validation_tools/schema_loader.py
@@ -27,7 +27,7 @@ SchemaVersion = namedtuple('SchemaVersion', ['schema_name', 'version'])
 def get_field_enum(field_name, schema):
     fields = [
         field for field in schema['fields']
-        if field['name'] == field_name
+        if not isinstance(field, str) and field['name'] == field_name
     ]
     if not fields:
         return []
@@ -158,12 +158,18 @@ def _get_schema_filename(schema_name, version):
     return f'{schema_name}-v{version}.yaml'
 
 
-def get_other_schema(schema_name, version, offline=None):
+def get_other_schema(schema_name, version, offline=None, keep_headers=False):
     schema = load_yaml(
         _table_schemas_path / 'others' /
         _get_schema_filename(schema_name, version))
-    names = [field['name'] for field in schema['fields']]
+    fields_wo_headers = [field for field in schema['fields'] if not isinstance(field, str)]
+    if not keep_headers:
+        schema['fields'] = fields_wo_headers
+
+    names = [field['name'] for field in fields_wo_headers]
     for field in schema['fields']:
+        if isinstance(field, str):
+            continue
         _add_constraints(field, optional_fields=[], offline=offline, names=names)
     return schema
 
@@ -173,13 +179,18 @@ def get_is_assay(schema_name):
     return schema_name not in ['donor', 'sample', 'antibodies', 'contributors']
 
 
-def get_table_schema(schema_name, version, optional_fields=[], offline=None):
+def get_table_schema(schema_name, version, optional_fields=[], offline=None, keep_headers=False):
     schema = load_yaml(
         _table_schemas_path / 'assays' /
         _get_schema_filename(schema_name, version))
+    fields_wo_headers = [field for field in schema['fields'] if not isinstance(field, str)]
+    if not keep_headers:
+        schema['fields'] = fields_wo_headers
 
-    names = [field['name'] for field in schema['fields']]
+    names = [field['name'] for field in fields_wo_headers]
     for field in schema['fields']:
+        if isinstance(field, str):
+            continue
         _add_level_1_description(field)
         # TODO: Re-enable when all assay names used in the schemas are recognized
         #       by the assay service, and the list in enums.py has been uncommented.

--- a/src/ingest_validation_tools/table-schemas/assays/af-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/af-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/af
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 
 - name: assay_category
@@ -17,6 +18,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/af-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/af-v1.yaml
@@ -1,6 +1,7 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/af
 description_md: This schema is for autofluorescence (AF). For an example of an AF dataset & directory, see this [example autofluorescence dataset](https://portal.hubmapconsortium.org/browse/dataset/dc289471333309925e46ceb9bafafaf4#files) and click the Globus link.
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 
 - name: assay_category
@@ -18,6 +19,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/bulkatacseq-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/bulkatacseq-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/bulk_transposition_input_number_nuclei.yaml
 # include: ../includes/fields/bulk_atac_cell_isolation_protocols_io_doi.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/bulkatacseq-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/bulkatacseq-v1.yaml
@@ -1,6 +1,7 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 description_md: This schema is for Assay for Transposase-Accessible Chromatin by sequencing (ATACseq)of bulk sample.
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -17,6 +18,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/bulk_transposition_input_number_nuclei.yaml
 # include: ../includes/fields/bulk_atac_cell_isolation_protocols_io_doi.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/bulkrnaseq-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/bulkrnaseq-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/bulk_rna_isolation_protocols_io_doi.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/bulkrnaseq-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/bulkrnaseq-v1.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/bulk_rna_isolation_protocols_io_doi.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/celldive-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/celldive-v0.yaml
@@ -8,6 +8,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -22,6 +23,7 @@ fields:
     enum:
       - protein
 # include: ../includes/v0/is_targeted.yaml
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/antibodies_channels.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/celldive-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/celldive-v1.yaml
@@ -8,6 +8,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -22,6 +23,7 @@ fields:
     enum:
       - protein
 # include: ../includes/v0/is_targeted.yaml
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/antibodies_channels.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/cems-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/cems-v1.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -22,6 +23,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/codex-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/codex-v0.yaml
@@ -9,6 +9,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:

--- a/src/ingest_validation_tools/table-schemas/assays/codex-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/codex-v0.yaml
@@ -25,8 +25,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 - name: acquisition_instrument_vendor
-  heading: Unique to this type
   description: An acquisition_instrument is the device that contains the signal detection hardware and signal processing software. Assays generate signals such as light of various intensities or color or signals representing molecular mass.
   constraints:
     enum: ['Keyence','Zeiss']
@@ -43,8 +43,8 @@ fields:
   constraints:
     required: False
 # include: ../includes/fields/resolution_z_unit.yaml
+- Level 3
 - name: preparation_instrument_vendor
-  heading: Level 3
   description: The manufacturer of the instrument used to prepare the sample for the assay.
   constraints:
     enum: ['CODEX']

--- a/src/ingest_validation_tools/table-schemas/assays/codex-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/codex-v1.yaml
@@ -26,8 +26,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 - name: acquisition_instrument_vendor
-  heading: Unique to this type
   description: An acquisition_instrument is the device that contains the signal detection hardware and signal processing software. Assays generate signals such as light of various intensities or color or signals representing molecular mass.
   constraints:
     enum: ['Keyence','Zeiss']

--- a/src/ingest_validation_tools/table-schemas/assays/codex-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/codex-v1.yaml
@@ -10,6 +10,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:

--- a/src/ingest_validation_tools/table-schemas/assays/gcms-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/gcms-v1.yaml
@@ -1,5 +1,6 @@
 description_md: This schema is for gas chromatography - mass spectrophotometry (GCMS).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -17,6 +18,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/imc-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/imc-v0.yaml
@@ -7,6 +7,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -24,6 +25,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/prep_instrument.yaml
 # include: ../includes/v0/doi/section_prep.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/imc-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/imc-v1.yaml
@@ -7,6 +7,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -24,6 +25,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/prep_instrument.yaml
 # include: ../includes/v0/doi/section_prep.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/imc3d-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/imc3d-v0.yaml
@@ -7,6 +7,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -24,6 +25,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/prep_instrument.yaml
 # include: ../includes/v0/doi/section_prep.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/imc3d-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/imc3d-v1.yaml
@@ -7,6 +7,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -24,6 +25,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/prep_instrument.yaml
 # include: ../includes/v0/doi/section_prep.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/ims-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -18,6 +19,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/ims-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v1.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -18,6 +19,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
@@ -32,6 +32,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
@@ -1,8 +1,8 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/maldi-ims
 description_md: This schema is for imaging mass spectrometry (IMS).
 fields:
+- Shared by all types
 - name: version
-  heading: Shared by all types
   description: Version of the schema to use when validating this metadata.
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/lcms-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lcms-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lcms
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -21,6 +22,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source
   description: The ion source type used for surface sampling (MALDI, MALDI-2, DESI, or SIMS) or LC-MS/MS data acquisition (nESI)

--- a/src/ingest_validation_tools/table-schemas/assays/lcms-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lcms-v1.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/lcms
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -21,6 +22,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source
   description: The ion source type used for surface sampling (MALDI, MALDI-2, DESI, or SIMS) or LC-MS/MS data acquisition (nESI)

--- a/src/ingest_validation_tools/table-schemas/assays/lcms-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lcms-v2.yaml
@@ -43,6 +43,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source
   description: The ion source type used for surface sampling.

--- a/src/ingest_validation_tools/table-schemas/assays/lcms-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lcms-v2.yaml
@@ -6,8 +6,8 @@ description_md:
   For an example of an LC-MS dataset & directory, see this [example LC-MS dataset](https://portal.hubmapconsortium.org/browse/dataset/7f1fd7b9c8c3745fcab037a2fa37f5b9) 
   and click the Globus link.
 fields:
+- Shared by all types
 - name: version
-  heading: Shared by all types
   description: Version of the schema to use when validating this metadata.
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/lcms-v3.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lcms-v3.yaml
@@ -10,8 +10,8 @@ description_md:
 
 release_date: 2021-12-06
 fields:
+- Shared by all types
 - name: version
-  heading: Shared by all types
   description: Version of the schema to use when validating this metadata.
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/lcms-v3.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lcms-v3.yaml
@@ -47,6 +47,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/dms.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/lightsheet-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lightsheet-v0.yaml
@@ -7,6 +7,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -23,6 +24,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml
 

--- a/src/ingest_validation_tools/table-schemas/assays/lightsheet-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lightsheet-v1.yaml
@@ -7,6 +7,7 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -23,6 +24,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml
 

--- a/src/ingest_validation_tools/table-schemas/assays/lightsheet-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lightsheet-v2.yaml
@@ -35,6 +35,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml
 

--- a/src/ingest_validation_tools/table-schemas/assays/lightsheet-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/lightsheet-v2.yaml
@@ -13,8 +13,8 @@ description_md: >-
   The other fields function the same way for all assays using antibodies.
   For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
+- Shared by all types
 - name: version
-  heading: Shared by all types
   description: Version of the schema to use when validating this metadata.
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/mibi-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/mibi-v1.yaml
@@ -1,6 +1,7 @@
 # doc_url: TODO
 description_md: This schema is for Multiplex Ion Beam Imaging (MIBI).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 
 - name: assay_category

--- a/src/ingest_validation_tools/table-schemas/assays/mxif-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/mxif-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/mxif
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/mxif-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/mxif-v1.yaml
@@ -1,6 +1,7 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/mxif
 description_md: This schema is for multiplex immunofluorescence microscopy (MxIF).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -17,6 +18,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/nano-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/nano-v0.yaml
@@ -1,6 +1,7 @@
 # doc_url: TODO https://github.com/hubmapconsortium/ingest-validation-tools/issues/481
 deprecated: True
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 
 - name: assay_category
@@ -19,6 +20,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/nano-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/nano-v1.yaml
@@ -1,6 +1,7 @@
 # doc_url: TODO https://github.com/hubmapconsortium/ingest-validation-tools/issues/481
 deprecated: True
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 
 - name: assay_category
@@ -19,6 +20,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: ms_source

--- a/src/ingest_validation_tools/table-schemas/assays/scatacseq-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scatacseq-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -19,6 +20,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: is_technical_replicate
   description: If TRUE, fastq files in dataset need to be merged.

--- a/src/ingest_validation_tools/table-schemas/assays/scatacseq-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scatacseq-v1.yaml
@@ -1,6 +1,7 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/atacseq
 description_md: This schema is for the single cell Assay for Transposase Accessible Chromatin by sequencing (scATACseq).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -20,6 +21,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: is_technical_replicate
   description: If TRUE, fastq files in dataset need to be merged.

--- a/src/ingest_validation_tools/table-schemas/assays/scrnaseq-hca-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scrnaseq-hca-v0.yaml
@@ -2,11 +2,11 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
 # include: ../includes/fields/source_project.yaml
+- Shared by all types
 - name: donor_id
   constraints:
     required: false
   description: HuBMAP Display ID of the donor of the assayed tissue.
-  heading: Shared by all types
   type: string
   custom_constraints:
     sequence_limit: False
@@ -81,13 +81,13 @@ fields:
   description: Specifies whether or not a specific molecule(s) is/are targeted for
     detection/measurement by the assay. For example, an antibody targets a specific protein.
   type: boolean
+- Unique to this type
 - name: acquisition_instrument_vendor
   constraints:
     required: true
   description: An acquisition instrument is the device that contains the signal detection
     hardware and signal processing software. Assays generate signals such as light
     of various intensities or color or signals representing the molecular mass.
-  heading: Unique to this type
 - name: acquisition_instrument_model
   constraints:
     required: true

--- a/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -20,6 +21,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: sc_isolation_protocols_io_doi
   description: "Link to a protocols document answering the question: How were single cells separated into a single-cell suspension?"

--- a/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v1.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -20,6 +21,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: sc_isolation_protocols_io_doi
   description: "Link to a protocols document answering the question: How were single cells separated into a single-cell suspension?"

--- a/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v2.yaml
@@ -28,6 +28,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: sc_isolation_protocols_io_doi
   description: "Link to a protocols document answering the question: How were single cells separated into a single-cell suspension?"

--- a/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v2.yaml
@@ -1,8 +1,8 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 description_md: This schema is for single cell RNA sequencing (scRNAseq).
 fields:
+- Shared by all types
 - name: version
-  heading: Shared by all types
   description: Version of the schema to use when validating this metadata.
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v3.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v3.yaml
@@ -28,6 +28,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 - name: sc_isolation_protocols_io_doi
   description: "Link to a protocols document answering the question: How were single cells separated into a single-cell suspension?"

--- a/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v3.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/scrnaseq-v3.yaml
@@ -1,8 +1,8 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/rnaseq
 description_md: This schema is for single cell RNA sequencing (scRNAseq). v3 adds `umi_*` fields.
 fields:
+- Shared by all types
 - name: version
-  heading: Shared by all types
   description: Version of the schema to use when validating this metadata.
   constraints:
     enum:

--- a/src/ingest_validation_tools/table-schemas/assays/seqfish-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/seqfish-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/seqfish
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/seqfish-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/seqfish-v1.yaml
@@ -1,6 +1,7 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/seqfish
 description_md: This schema is for spatial sequencing by fluorescence in situ hybridization (seqFISH).
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -17,6 +18,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/slideseq-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/slideseq-v0.yaml
@@ -1,5 +1,6 @@
 # doc_url: TODO https://github.com/hubmapconsortium/ingest-validation-tools/issues/482
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/rnaseq_assay_method.yaml
 - name: library_construction_protocols_io_doi

--- a/src/ingest_validation_tools/table-schemas/assays/slideseq-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/slideseq-v1.yaml
@@ -1,5 +1,6 @@
 # doc_url: TODO https://github.com/hubmapconsortium/ingest-validation-tools/issues/482
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/rnaseq_assay_method.yaml
 - name: library_construction_protocols_io_doi

--- a/src/ingest_validation_tools/table-schemas/assays/stained-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/stained-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/pas
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -15,6 +16,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/stained-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/stained-v1.yaml
@@ -4,6 +4,7 @@ description_md: This schema is for microscopy of tissue treated with periodic ac
   [example PAS stained dataset](https://portal.hubmapconsortium.org/browse/dataset/7308530b92438fdbe258b501aeb86069#files) 
   and click the Globus link.
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -19,6 +20,7 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2 fields:
+- Unique to this type
 
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/v0/x_y.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/wgs-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/wgs-v0.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/wgs
 fields:
+- Shared by all types
 # include: ../includes/v0/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/gdna_fragmentation_quality_assurance.yaml
 # include: ../includes/fields/dna_assay_input_value.yaml

--- a/src/ingest_validation_tools/table-schemas/assays/wgs-v1.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/wgs-v1.yaml
@@ -1,5 +1,6 @@
 doc_url: https://portal.hubmapconsortium.org/docs/assays/wgs
 fields:
+- Shared by all types
 # include: ../includes/vA/all_assays.yaml
 - name: assay_category
   constraints:
@@ -16,6 +17,8 @@ fields:
 # include: ../includes/v0/is_targeted.yaml
 
 # Level 2:
+- Unique to this type
+
 # include: ../includes/v0/acquisition_instrument.yaml
 # include: ../includes/fields/gdna_fragmentation_quality_assurance.yaml
 # include: ../includes/fields/dna_assay_input_value.yaml

--- a/src/ingest_validation_tools/table-schemas/includes/v0/acquisition_instrument.yaml
+++ b/src/ingest_validation_tools/table-schemas/includes/v0/acquisition_instrument.yaml
@@ -1,5 +1,5 @@
+- Unique to this type
 -
-  heading: Unique to this type
   name: acquisition_instrument_vendor
   description: An acquisition instrument is the device that contains the signal detection hardware and signal processing software.
     Assays generate signals such as light of various intensities or color or signals representing the molecular mass.

--- a/src/ingest_validation_tools/table-schemas/includes/v0/acquisition_instrument.yaml
+++ b/src/ingest_validation_tools/table-schemas/includes/v0/acquisition_instrument.yaml
@@ -1,4 +1,3 @@
-- Unique to this type
 -
   name: acquisition_instrument_vendor
   description: An acquisition instrument is the device that contains the signal detection hardware and signal processing software.

--- a/src/ingest_validation_tools/table-schemas/includes/v0/all_assays.yaml
+++ b/src/ingest_validation_tools/table-schemas/includes/v0/all_assays.yaml
@@ -1,5 +1,5 @@
+- Shared by all types
 -
-  heading: Shared by all types
   name: donor_id
   description: HuBMAP Display ID of the donor of the assayed tissue.
   constraints:

--- a/src/ingest_validation_tools/table-schemas/includes/v0/all_assays.yaml
+++ b/src/ingest_validation_tools/table-schemas/includes/v0/all_assays.yaml
@@ -1,4 +1,3 @@
-- Shared by all types
 -
   name: donor_id
   description: HuBMAP Display ID of the donor of the assayed tissue.

--- a/src/ingest_validation_tools/table-schemas/includes/vA/all_assays.yaml
+++ b/src/ingest_validation_tools/table-schemas/includes/vA/all_assays.yaml
@@ -1,4 +1,3 @@
-- Shared by all types
 -
   name: version
   description: Version of the schema to use when validating this metadata.

--- a/src/ingest_validation_tools/table-schemas/includes/vA/all_assays.yaml
+++ b/src/ingest_validation_tools/table-schemas/includes/vA/all_assays.yaml
@@ -1,5 +1,5 @@
+- Shared by all types
 -
-  heading: Shared by all types
   name: version
   description: Version of the schema to use when validating this metadata.
   constraints:

--- a/src/ingest_validation_tools/table-schemas/others/sample-v0.yaml
+++ b/src/ingest_validation_tools/table-schemas/others/sample-v0.yaml
@@ -1,13 +1,13 @@
 fields:
+- IDs
 -
-  heading: IDs
   name: sample_id
   description: (No description for this field was supplied.)
   constraints:
     required: True
     pattern: '([A-Z]+[0-9]+)-[A-Z]{2}\d*(-\d+)+(_\d+)?'
+- Donor
 -
-  heading: Donor
   name: vital_state
   constraints:
     required: True
@@ -27,8 +27,8 @@ fields:
     is collected, the subject will be deemed “relatively healthy”.   Likewise, a relatively healthy subject may have
     experienced trauma leading to brain death.  As a result of organ donation, a sample is collected.  In this scenario,
     the subject is deemed “relatively healthy.”
+- Medical Procedure
 -
-  heading: Medical Procedure
   name: organ_condition
   constraints:
     required: True
@@ -82,8 +82,8 @@ fields:
     required: True
     enum:
       - minutes
+- Biospecimen
 -
-  heading: Biospecimen
   name: specimen_preservation_temperature
   constraints:
     required: True


### PR DESCRIPTION
Formerly, section headers were a property of the first field of the section. Semantically, this isn't quite right, and it made field template use more awkward. This PR:
- Adds code support for this new structure.
- Moves the headers out of the field templates, up to the top level.
- *Does not* change any of the markdown output: The CHANGELOG is the only `.md` file that's touched in this PR.