### PR TITLE
mibi: add Ab path and description.md text

### DIFF
--- a/docs/mibi/v1.yaml
+++ b/docs/mibi/v1.yaml
@@ -1,5 +1,8 @@
 # Generated YAML: PRs should not start here!
-description_md: This schema is for Multiplex Ion Beam Imaging (MIBI).
+description_md: This schema is for Multiplex Ion Beam Imaging (MIBI). For MIBI, 
+the channel_id (in the Antibodies TSV) is the name of the metal tag on the corresponding antibody. 
+The other fields function the same way for all assays using antibodies. 
+For more information, see the [Antibodies TSV documentation](../antibodies).
 fields:
 - Shared by all types
 - constraints:
@@ -453,6 +456,13 @@ fields:
   format: '%Y-%m-%d %H:%M'
   name: start_datetime
   type: datetime
+- constraints:
+    required: true
+  custom_constraints:
+    forbid_na: true
+    sequence_limit: 3
+  description: Relative path to file with antibody information for this dataset.
+  name: antibodies_path
 - constraints:
     required: true
   custom_constraints:


### PR DESCRIPTION
added an antibodies_path field to the schema & text to the description.md. @ngehlenborg I believe this can also be added while keeping the same version.