### PR TITLE
ignore deprecation flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.14 - in progress
+- Add CLI option to allow the use of deprecated schemas.
 - Add acquisition instrument fields to MIBI that were left out by mistake.
 - Just use pytest to run doctests
 - Headers are no longer properties of fields.

--- a/script-docs/README-validate_upload.py.md
+++ b/script-docs/README-validate_upload.py.md
@@ -1,7 +1,7 @@
 ```text
 usage: validate_upload.py [-h] --local_directory PATH
                           [--optional_fields FIELD [FIELD ...]] [--offline]
-                          [--clear_cache]
+                          [--clear_cache] [--ignore_deprecation]
                           [--dataset_ignore_globs GLOB [GLOB ...]]
                           [--upload_ignore_globs GLOB [GLOB ...]]
                           [--encoding ENCODING]
@@ -21,6 +21,8 @@ optional arguments:
                         they are supplied in the TSV, they will be validated.)
   --offline             Skip checks that require network access.
   --clear_cache         Clear cache of network check responses.
+  --ignore_deprecation  Allow validation against deprecated versions of
+                        metadata schemas.
   --dataset_ignore_globs GLOB [GLOB ...]
                         Matching files in each dataset directory will be
                         ignored. Default: .*

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -30,7 +30,8 @@ class Upload:
     def __init__(self, directory_path=None, tsv_paths=[],
                  optional_fields=[], add_notes=True,
                  dataset_ignore_globs=[], upload_ignore_globs=[],
-                 plugin_directory=None, encoding=None, offline=None):
+                 plugin_directory=None, encoding=None, offline=None,
+                 ignore_deprecation=False):
         self.directory_path = directory_path
         self.optional_fields = optional_fields
         self.dataset_ignore_globs = dataset_ignore_globs
@@ -39,6 +40,7 @@ class Upload:
         self.encoding = encoding
         self.offline = offline
         self.add_notes = add_notes
+        self.ignore_deprecation = ignore_deprecation
         self.errors = {}
         self.effective_tsv_paths = {}
         try:
@@ -178,13 +180,15 @@ class Upload:
         else:
             return get_tsv_errors(
                 schema_name=ref_type, tsv_path=path,
-                offline=self.offline, encoding=self.encoding)
+                offline=self.offline, encoding=self.encoding,
+                ignore_deprecation=self.ignore_deprecation)
 
     def __get_assay_tsv_errors(self, assay_type, path):
         return get_tsv_errors(
             schema_name=assay_type, tsv_path=path,
             offline=self.offline, encoding=self.encoding,
-            optional_fields=self.optional_fields)
+            optional_fields=self.optional_fields,
+            ignore_deprecation=self.ignore_deprecation)
 
     def __get_assay_reference_errors(self, assay_type, path):
         try:

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -81,7 +81,9 @@ def get_context_of_decode_error(e):
     return f'Invalid {e.encoding} because {e.reason}: "{in_context}"'
 
 
-def get_tsv_errors(tsv_path, schema_name, optional_fields=[], offline=None, encoding=None):
+def get_tsv_errors(
+        tsv_path, schema_name, optional_fields=[],
+        offline=None, encoding=None, ignore_deprecation=False):
     '''
     Validate the TSV.
 
@@ -159,7 +161,7 @@ def get_tsv_errors(tsv_path, schema_name, optional_fields=[], offline=None, enco
     except OSError as e:
         return {e.strerror: Path(e.filename).name}
 
-    if schema.get('deprecated'):
+    if schema.get('deprecated') and not ignore_deprecation:
         return {'Schema version is deprecated': f'{schema_name}-v{version}'}
 
     return get_table_errors(tsv_path, schema)

--- a/src/validate_upload.py
+++ b/src/validate_upload.py
@@ -63,6 +63,10 @@ Exit status codes:
         '--clear_cache', action='store_true',
         help='Clear cache of network check responses.'
     )
+    parser.add_argument(
+        '--ignore_deprecation', action='store_true',
+        help='Allow validation against deprecated versions of metadata schemas.'
+    )
 
     default_ignore = '.*'
     parser.add_argument(
@@ -129,7 +133,8 @@ def main():
         'add_notes': args.add_notes,
         'encoding': args.encoding,
         'offline': args.offline,
-        'optional_fields': args.optional_fields
+        'optional_fields': args.optional_fields,
+        'ignore_deprecation': args.ignore_deprecation
     }
 
     if args.local_directory:


### PR DESCRIPTION
Towards #1037, I think.

@jswelling : If you're checking out an older version as a hack, then even without this being merged to master, it might be useful to you, if you'd like to check out this version in airflow. Can you explain how you'll use this option? 
- Will it be on all the time, or will you just turn it on sporadically?
- Would it be useful to make it more fine grained, to only allow deprecated versions for some schemas? Or would that be gratuitous?
- Would it be useful to emit some kind of warning, even if the flag is set? (I haven't been excited about implementing warnings that aren't failures... adds complexity to the code / makes validation criteria less clear-cut.)