### PR TITLE
IMS schema edits to accommodate nanoDESI

### DIFF
--- a/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
+++ b/src/ingest_validation_tools/table-schemas/assays/ims-v2.yaml
@@ -36,7 +36,7 @@ fields:
 - Unique to this type
 
 - name: ms_source
-  description: The ion source type used for surface sampling (MALDI, MALDI-2, DESI, or SIMS) or LC-MS/MS data acquisition (nESI)
+  description: The ion source type used for surface sampling (MALDI, MALDI-2, DESI, nanoDESI or SIMS).
   constraints:
     enum:
       - MALDI
@@ -45,7 +45,6 @@ fields:
       - LA
       - SIMS-C60
       - SIMS-H2O
-      - ESI
       - nanoDESI
 # include: ../includes/fields/polarity.yaml
 # include: ../includes/fields/mz_range_low_value.yaml
@@ -56,6 +55,7 @@ fields:
 - name: ms_scan_mode
   description: Scan mode refers to the number of steps in the separation of fragments.
   constraints:
+    required: TRUE
     enum:
       - MS
       - MS/MS
@@ -81,8 +81,9 @@ fields:
 - name: preparation_maldi_matrix
   description: The matrix is a compound of crystallized molecules that acts like a
     buffer between the sample and the laser. It also helps ionize the sample, carrying
-    it along the flight tube so it can be detected.
+    it along the flight tube so it can be detected. Leave blank if not applicable.
   constraints:
+     required: False
      enum:
          - CHB
          - DHB


### PR DESCRIPTION
Changes I made in the yaml:
ms_source- Edited description. Removed ESI, added nanoDESI from enums.
ms_scan- Changed to required: TRUE
preparation_maldi_matrix- Changed to required: FALSE

I can't change 'includes' yamls. 
Would you please make these 2 fields required: TRUE ?
 include: ../includes/fields/mass_resolving_power.yaml
 include: ../includes/fields/mz_resolving_power.yaml