### PR TITLE
Test under 3.6 and 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,15 @@ jobs:
       matrix:
         version:
           - '3.6' # The Red Hat version used by IEC doesn't support anything more recent. :(
-          - '3.10' # ... but it should also work in modern environments!
+          - '3.10' # ... but this repo should also work in modern environments!
+
+          # TODO: Python 3.10 doesn't work for me, locally:
+          # 'pip install requirements-dev.txt' fails...
+          # Something wrong with typed-ast?
+          # ... but if it works on CI, great!
+          #
+          # Python 3.9 does work for me locally:
+          # Will wait for someone else to have trouble with 3.10 before investing any time here.
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,21 @@ jobs:
     # https://github.com/Ensembl/ensembl-rest/issues/427
     runs-on: ubuntu-18.04
 
+    strategy:
+      matrix:
+        version:
+          - '3.6' # The Red Hat version used by IEC doesn't support anything more recent. :(
+          - '3.10' # ... but it should also work in modern environments!
+
     steps:
     - uses: actions/checkout@v2
       # with:
       #   submodules: 'recursive'
 
-    - name: Set up Python 3.6
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6' # The Red Hat version used by IEC doesn't support anything more recent. :(
+        python-version: ${{ matrix.version }}
         architecture: 'x64'
 
     - name: Install python main dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## v0.0.14 - in progress
+- Test under both Python 3.6 and Python 3.10
 - Fix rendering bug on CODEX page by adding linebreaks.
 - Add type hints.
 - Implement versioning for directory schemas.

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -2,7 +2,6 @@ import logging
 from csv import DictReader
 from pathlib import Path
 from typing import List, Optional
-from collections import OrderedDict
 
 from ingest_validation_tools.schema_loader import (
     SchemaVersion, get_table_schema, get_other_schema,
@@ -20,7 +19,7 @@ class TableValidationErrors(Exception):
     pass
 
 
-def dict_reader_wrapper(path, encoding: str) -> List[OrderedDict]:
+def dict_reader_wrapper(path, encoding: str) -> list:
     with open(path, encoding=encoding) as f:
         rows = list(DictReader(f, dialect='excel-tab'))
     return rows

--- a/tests/test-script-docs.sh
+++ b/tests/test-script-docs.sh
@@ -8,11 +8,14 @@ for TOOL in src/*.py; do
   TOOL=`basename $TOOL`
   echo "Testing $TOOL docs..."
   [ -e src/$TOOL ] || die "src/$TOOL does not exist."
+
   # In python 3.10, this string changed.
   # Since we want the doc build to be the same in all environments, use perl to search and replace.
   DOC_CMD="src/$TOOL -h | perl -pne 's/options:/optional arguments:/'"
-  diff \
-        <(perl -ne 'print if /usage: '$TOOL'/../```/ and ! /```/' $DOCS/README-$TOOL.md) \
-        <($DOC_CMD) \
+
+  perl -ne 'print if /usage: '$TOOL'/../```/ and ! /```/' $DOCS/README-$TOOL.md > /tmp/expected.txt
+  eval $DOC_CMD > /tmp/actual.txt
+
+  diff /tmp/expected.txt /tmp/actual.txt \
       || die 'Update: (echo '"'"'```text'"'"'; '$DOC_CMD'; echo '"'"'```'"'"') >' $DOCS/README-$TOOL.md
 done

--- a/tests/test-script-docs.sh
+++ b/tests/test-script-docs.sh
@@ -8,8 +8,11 @@ for TOOL in src/*.py; do
   TOOL=`basename $TOOL`
   echo "Testing $TOOL docs..."
   [ -e src/$TOOL ] || die "src/$TOOL does not exist."
+  # In python 3.10, this string changed.
+  # Since we want the doc build to be the same in all environments, use perl to search and replace.
+  DOC_CMD="src/$TOOL -h | perl -pne 's/options:/optional arguments:/'"
   diff \
         <(perl -ne 'print if /usage: '$TOOL'/../```/ and ! /```/' $DOCS/README-$TOOL.md) \
-        <(src/$TOOL -h) \
-      || die 'Update: (echo '"'"'```text'"'"'; src/'$TOOL' -h; echo '"'"'```'"'"') >' $DOCS/README-$TOOL.md
+        <($DOC_CMD) \
+      || die 'Update: (echo '"'"'```text'"'"'; '$DOC_CMD'; echo '"'"'```'"'"') >' $DOCS/README-$TOOL.md
 done


### PR DESCRIPTION
- Fix #1084
- When I've done version matrices, I've generally just done the endpoints... but if some library was really important, intermediate versions could be checked, too.
- I'm not using type annotations well: I think the right thing is to use interfaces rather than concrete types... but that's more importing. 
- Just loosening parametric types isn't great either... but there was some change in the signature of the DictReader in the stdlib... and it didn't feel like the best use of time to get to the root of it.
- Doc generation also changed in 3.10... Maybe this doesn't even belong in tests, but if it's here, we want the behavior to be consistent between versions... and a perl-one-liner is my usual hammer for string replacement.