### PR TITLE
Mccalluc/remove html opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## v0.0.14 - in progress
+- Remove HTML reporting options.
 - Updated IMS directory structure schema.
 - Add Clinical Imaging schemas.
 - Test under both Python 3.6 and Python 3.10

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,5 @@
 jsonschema==3.2.0
 pyyaml>=5.3.1
 frictionless==4.0.0
-yattag==1.14.0
 tableschema-to-template==0.0.11
 requests==2.22.0  # Set to match version in hubmap commons.

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,9 +178,6 @@ xlsxwriter==3.0.3 \
     --hash=sha256:df0aefe5137478d206847eccf9f114715e42aaea077e6a48d0e8a2152e983010 \
     --hash=sha256:e89f4a1d2fa2c9ea15cde77de95cd3fd8b0345d0efb3964623f395c8c4988b7f
     # via tableschema-to-template
-yattag==1.14.0 \
-    --hash=sha256:5731a31cb7452c0c6930dd1a284e0170b39eee959851a2aceb8d6af4134a5fa8
-    # via -r requirements.in
 zipp==3.6.0 \
     --hash=sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832 \
     --hash=sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc

--- a/script-docs/README-validate_tsv.py.md
+++ b/script-docs/README-validate_tsv.py.md
@@ -1,7 +1,7 @@
 ```text
 usage: validate_tsv.py [-h] --path PATH --schema
                        {sample,sample-block,sample-suspension,sample-section,antibodies,contributors,metadata}
-                       [--output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}]
+                       [--output {as_md,as_text,as_text_list,as_yaml}]
 
 Validate a HuBMAP TSV.
 
@@ -9,7 +9,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --path PATH           TSV path
   --schema {sample,sample-block,sample-suspension,sample-section,antibodies,contributors,metadata}
-  --output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}
+  --output {as_md,as_text,as_text_list,as_yaml}
 
 Exit status codes:
   0: Validation passed

--- a/script-docs/README-validate_upload.py.md
+++ b/script-docs/README-validate_upload.py.md
@@ -6,7 +6,7 @@ usage: validate_upload.py [-h] --local_directory PATH
                           [--upload_ignore_globs GLOB [GLOB ...]]
                           [--encoding ENCODING]
                           [--plugin_directory PLUGIN_DIRECTORY]
-                          [--output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}]
+                          [--output {as_md,as_text,as_text_list,as_yaml}]
                           [--add_notes] [--save_report]
 
 Validate a HuBMAP upload, both the metadata TSVs and the datasets.
@@ -35,7 +35,7 @@ optional arguments:
                         tools/issues/494
   --plugin_directory PLUGIN_DIRECTORY
                         Directory of plugin tests.
-  --output {as_browser,as_html_doc,as_html_fragment,as_md,as_text,as_text_list,as_yaml}
+  --output {as_md,as_text,as_text_list,as_yaml}
   --add_notes           Append a context note to error reports.
   --save_report         Save the report; Adding "--upload_ignore_globs
                         'report-*.txt'" is necessary to revalidate.

--- a/src/ingest_validation_tools/error_report.py
+++ b/src/ingest_validation_tools/error_report.py
@@ -1,6 +1,4 @@
-from datetime import datetime
 from yaml import Dumper, dump
-from webbrowser import open_new_tab
 from pathlib import Path
 from typing import List
 
@@ -87,55 +85,3 @@ def _build_list(anything, path=None) -> List[str]:
             return to_return
     else:
         return [f'{prefix}{anything}']
-
-
-def _build_doc(tag, line, anything):
-    '''
-    >>> doc, tag, text, line = Doc().ttl()
-    >>> _build_doc(tag, line, {
-    ...     'nested dict': {
-    ...         'like': 'this'
-    ...     },
-    ...     'nested array': [
-    ...         'like',
-    ...         'this'
-    ...     ]
-    ... })
-    >>> print(indent(doc.getvalue()))
-    <details>
-      <summary>nested dict</summary>
-      <dl>
-        <dt>like</dt>
-        <dd>this</dd>
-      </dl>
-    </details>
-    <details>
-      <summary>nested array</summary>
-      <ul>
-        <li>like</li>
-        <li>this</li>
-      </ul>
-    </details>
-
-    '''
-    if isinstance(anything, dict):
-        if all(isinstance(v, (float, int, str)) for v in anything.values()):
-            with tag('dl'):
-                for k, v in anything.items():
-                    line('dt', k)
-                    line('dd', v)
-        else:
-            for k, v in anything.items():
-                with tag('details'):
-                    line('summary', k)
-                    _build_doc(tag, line, v)
-    elif isinstance(anything, list):
-        if all(isinstance(v, (float, int, str)) for v in anything):
-            with tag('ul'):
-                for v in anything:
-                    line('li', v)
-        else:
-            for v in anything:
-                _build_doc(tag, line, v)
-    else:
-        line('div', anything)


### PR DESCRIPTION
Back at the start of this, I had thought that structuring the error list hierarchically would be readable, and an html structure with collapsible sections would be the easiest way to review this kind of structure... But Bill suggested that what folks really want is just a flat, human readable list, and my sense is that that's the format that gets used.

This PR removes the HTML generation code; The motivation is:
- #1090

With the output changing, a bit of work would be required here, so seems like a good time to simplify... but if it turns out that someone actually needs/wants this, it wouldn't be hard to bring it back, and do the additional work that's needed. We don't have a user-group email list, and even if we did, I think I would lean towards asking for forgiveness rather than permission... but I could be making the wrong call.

If this is approved, I would plan to merge this into main, and then merge than into #1090.