### PR TITLE
Reactivate enums.py doctest; uncomment 6 MS assays

### DIFF
--- a/src/ingest_validation_tools/enums.py
+++ b/src/ingest_validation_tools/enums.py
@@ -1,25 +1,5 @@
 from typing import Dict, List
 
-
-'''
->>> import requests
->>> local_names = shared_enums['assay_type']
->>> remote_mismatch = []
->>> for name in local_names:
-...     response = requests.post(
-...         'https://search.api.hubmapconsortium.org/assayname',
-...         json={'name':name}, headers={'Content-Type': 'application/json'}).json()
-...     if 'error' in response:
-...         remote_mismatch.append(name)
->>> print('\\n'.join(remote_mismatch))
-<BLANKLINE>
-'''
-# The list above should be empty: That means that all the assays
-# listed below are recognized by the assay service.
-# TODO: Joel will progressively uncomment names below, and when that is done
-#       _validate_level_1_enum() can be renabled in schema_loader.py.
-#       https://github.com/hubmapconsortium/ingest-validation-tools/issues/1023
-
 shared_enums: Dict[str, List[str]] = {
     'assay_category': [
         'imaging',
@@ -67,12 +47,12 @@ shared_enums: Dict[str, List[str]] = {
         'snRNAseq-10xGenomics-v3',
         # 'scRNAseq',
         'Slide-seq',
-        # 'MS Bottom-Up',
-        # 'MS Top-Down',
-        # 'LC-MS Top-Down',
-        # 'LC-MS',
-        # 'LC-MS Bottom-Up',
-        # 'MS'
+        'MS Bottom-Up',
+        'MS Top-Down',
+        'LC-MS Top-Down',
+        'LC-MS',
+        'LC-MS Bottom-Up',
+        'MS'
     ],
     'analyte_class': [
         'DNA',
@@ -87,3 +67,27 @@ shared_enums: Dict[str, List[str]] = {
         'phosphopeptides'
     ]
 }
+
+def _test_assay_name_compatibility():
+    """
+    >>> import requests
+    >>> local_names = shared_enums['assay_type']
+    >>> remote_mismatch = []
+    >>> for name in local_names:
+    ...     response = requests.post(
+    ...         'https://search.api.hubmapconsortium.org/assayname',
+    ...         json={'name':name}, headers={'Content-Type': 'application/json'}).json()
+    ...     if 'error' in response:
+    ...         remote_mismatch.append(name)
+    >>> print('\\n'.join(remote_mismatch))
+    <BLANKLINE>
+    """
+    # The list above should be empty: That means that all the assays
+    # listed below are recognized by the assay service.
+    # TODO: Joel will progressively uncomment names below, and when that is done
+    #       _validate_level_1_enum() can be renabled in schema_loader.py.
+    #       https://github.com/hubmapconsortium/ingest-validation-tools/issues/1023
+    pass
+
+if __name__ == "__main__":
+    main()

--- a/src/ingest_validation_tools/enums.py
+++ b/src/ingest_validation_tools/enums.py
@@ -89,5 +89,3 @@ def _test_assay_name_compatibility():
     #       https://github.com/hubmapconsortium/ingest-validation-tools/issues/1023
     pass
 
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
This PR reactivates the doctest in enums.py, and uncomments the following assays: 'MS Bottom-Up', 'MS Top-Down', 'LC-MS Top-Down', 'LC-MS', 'LC-MS Bottom-Up', 'MS'.  It requires https://github.com/hubmapconsortium/search-api/pull/496 , and will not pass CI until that PR has been deployed.
