### PR TITLE
make segmentation.json required

### DIFF
--- a/src/ingest_validation_tools/directory-schemas/codex-v0.yaml
+++ b/src/ingest_validation_tools/directory-schemas/codex-v0.yaml
@@ -14,7 +14,7 @@ files:
   - 
     pattern: '(raw|processed)/config\.txt|(src_[^/]*|drv_[^/]*|extras)/[sS]egmentation\.json' 
     description: 'Sanity check that verifies the existence of at least one of these files. This is required for the HuBMAP processing pipeline' 
-    required: False 
+    required: True
   -
     example: 'raw/reg_00.png'
     pattern: 'raw/reg_[^/]*\.png'


### PR DESCRIPTION
This file `segmentaiton.json` is necessary for the pipeline to run and should be present in CODEX datasets that don't have `dataset.json`