### PR TITLE
Use the assay service to describe assays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## v0.0.15 - in progress
+- Use the assay service to describe how assays are represented in the Portal.
 
 ## v0.0.14 - 2022-06-23
 - Turn validation of enums back on.

--- a/docs/af/index.md
+++ b/docs/af/index.md
@@ -26,6 +26,8 @@ This schema is for autofluorescence (AF). For an example of an AF dataset & dire
 
 
 
+In the portal: [Autofluorescence Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Autofluorescence+Microscopy&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/antibodies/index.md
+++ b/docs/antibodies/index.md
@@ -17,6 +17,8 @@ Changes:
 
 
 
+
+
 ## Metadata schema
 
 ### Field types

--- a/docs/bodyct/index.md
+++ b/docs/bodyct/index.md
@@ -15,6 +15,8 @@ This schema is for clinical imaging using body computed tomography (Body CT).
 
 
 
+In the portal: Body CT not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/bulkatacseq/index.md
+++ b/docs/bulkatacseq/index.md
@@ -23,6 +23,8 @@ This schema is for Assay for Transposase-Accessible Chromatin by sequencing (ATA
 
 
 
+In the portal: [Bulk ATAC-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Bulk+ATAC-seq&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/bulkrnaseq/index.md
+++ b/docs/bulkrnaseq/index.md
@@ -23,6 +23,8 @@ Related files:
 
 
 
+In the portal: [Bulk RNA-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Bulk+RNA-seq&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/celldive/index.md
+++ b/docs/celldive/index.md
@@ -27,6 +27,8 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
+In the portal: [Cell DIVE](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Cell+DIVE&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/cems/index.md
+++ b/docs/cems/index.md
@@ -23,6 +23,8 @@ Related files:
 
 
 
+In the portal: CE-MS not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/codex/index.md
+++ b/docs/codex/index.md
@@ -57,6 +57,8 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
+In the portal: [CODEX](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=CODEX&entity_type%5B0%5D=Dataset) / [CODEX (CODEX2 assay type)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=CODEX+%28CODEX2+assay+type%29&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -15,6 +15,8 @@ Related files:
 
 
 
+
+
 ## Metadata schema
 
 ### Field types

--- a/docs/donor/index.md
+++ b/docs/donor/index.md
@@ -16,6 +16,8 @@ Most definitions taken from https://ncit.nci.nih.gov/ncitbrowser/pages/home.jsf?
 
 
 
+
+
 ## Metadata schema
 
 ### Field types

--- a/docs/gcms/index.md
+++ b/docs/gcms/index.md
@@ -23,6 +23,8 @@ This schema is for gas chromatography - mass spectrophotometry (GCMS).
 
 
 
+In the portal: GC-MS not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/imc/index.md
+++ b/docs/imc/index.md
@@ -24,6 +24,8 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
+In the portal: [Imaging Mass Cytometry (2D)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Imaging+Mass+Cytometry+%282D%29&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/imc3d/index.md
+++ b/docs/imc3d/index.md
@@ -34,6 +34,8 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
+In the portal: [Imaging Mass Cytometry (3D)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Imaging+Mass+Cytometry+%283D%29&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/ims/index.md
+++ b/docs/ims/index.md
@@ -30,6 +30,8 @@ This schema is for imaging mass spectrometry (IMS).
 
 
 
+In the portal: [MALDI IMS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MALDI+IMS&entity_type%5B0%5D=Dataset) / SIMS-IMS not in Portal / [NanoDESI](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=NanoDESI&entity_type%5B0%5D=Dataset) / DESI not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/lcms/index.md
+++ b/docs/lcms/index.md
@@ -28,6 +28,8 @@ v3 adds `dms` and `label_name` fields, and `negative and positive ion mode` as a
 
 
 
+In the portal: [LC-MS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=LC-MS&entity_type%5B0%5D=Dataset) / [MS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MS&entity_type%5B0%5D=Dataset) / [LC-MS Bottom Up](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=LC-MS+Bottom+Up&entity_type%5B0%5D=Dataset) / [MS Bottom Up](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MS+Bottom+Up&entity_type%5B0%5D=Dataset) / [LC-MS Top Down](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=LC-MS+Top+Down&entity_type%5B0%5D=Dataset) / [MS Top Down](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MS+Top+Down&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/lightsheet/index.md
+++ b/docs/lightsheet/index.md
@@ -37,6 +37,8 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
+In the portal: [Lightsheet Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Lightsheet+Microscopy&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/mibi/index.md
+++ b/docs/mibi/index.md
@@ -34,6 +34,8 @@ This schema is for Multiplex Ion Beam Imaging (MIBI). For MIBI, the channel_id (
 
 
 
+In the portal: [Multiplex Ion Beam Imaging](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Multiplex+Ion+Beam+Imaging&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/microct/index.md
+++ b/docs/microct/index.md
@@ -15,6 +15,8 @@ This schema is for clinical imaging using micro computed tomography (Micro CT).
 
 
 
+In the portal: Micro CT not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/mri/index.md
+++ b/docs/mri/index.md
@@ -15,6 +15,8 @@ This schema is for clinical imaging using magnetic resonance imaging (MRI).
 
 
 
+In the portal: MRI not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/mxif/index.md
+++ b/docs/mxif/index.md
@@ -23,6 +23,8 @@ This schema is for multiplex immunofluorescence microscopy (MxIF).
 
 
 
+In the portal: [Multiplexed IF Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Multiplexed+IF+Microscopy&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/nano/index.md
+++ b/docs/nano/index.md
@@ -30,6 +30,8 @@ Related files:
 
 
 
+In the portal: [NanoDESI](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=NanoDESI&entity_type%5B0%5D=Dataset) / [NanoPOTS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=NanoPOTS&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/oct/index.md
+++ b/docs/oct/index.md
@@ -15,6 +15,8 @@ This schema is for clinical imaging using optical coherence tomography (OCT).
 
 
 
+In the portal: OCT not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/sample-block/index.md
+++ b/docs/sample-block/index.md
@@ -15,6 +15,8 @@ Related files:
 
 
 
+
+
 ## Metadata schema
 
 ### Field types

--- a/docs/sample-section/index.md
+++ b/docs/sample-section/index.md
@@ -15,6 +15,8 @@ Related files:
 
 
 
+
+
 ## Metadata schema
 
 ### Field types

--- a/docs/sample-suspension/index.md
+++ b/docs/sample-suspension/index.md
@@ -15,6 +15,8 @@ Related files:
 
 
 
+
+
 ## Metadata schema
 
 ### Field types

--- a/docs/sample/index.md
+++ b/docs/sample/index.md
@@ -15,6 +15,8 @@ Related files:
 
 
 
+
+
 ## Metadata schema
 
 ### Field types

--- a/docs/scatacseq/index.md
+++ b/docs/scatacseq/index.md
@@ -25,6 +25,8 @@ The HIVE will process each dataset with
 
 
 
+In the portal: [snATACseq (SNARE-seq2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snATACseq+%28SNARE-seq2%29&entity_type%5B0%5D=Dataset) / [sciATAC-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=sciATAC-seq&entity_type%5B0%5D=Dataset) / [snATAC-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snATAC-seq&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/scrnaseq/index.md
+++ b/docs/scrnaseq/index.md
@@ -23,6 +23,8 @@ This schema is for single cell RNA sequencing (scRNAseq). v3 adds `umi_*` fields
 
 
 
+In the portal: [scRNA-seq (10x Genomics v2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=scRNA-seq+%2810x+Genomics+v2%29&entity_type%5B0%5D=Dataset) / [scRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=scRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v2%29&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / scRNAseq not in Portal / [sciRNA-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=sciRNA-seq&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / [snRNAseq (SNARE-seq2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNAseq+%28SNARE-seq2%29&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/seqfish/index.md
+++ b/docs/seqfish/index.md
@@ -23,6 +23,8 @@ This schema is for spatial sequencing by fluorescence in situ hybridization (seq
 
 
 
+In the portal: [seqFISH](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=seqFISH&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/slideseq/index.md
+++ b/docs/slideseq/index.md
@@ -34,6 +34,8 @@ Related files:
 
 
 
+In the portal: [Slide-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Slide-seq&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/stained/index.md
+++ b/docs/stained/index.md
@@ -26,6 +26,8 @@ This schema is for microscopy of tissue treated with periodic acid–Schiff stai
 
 
 
+In the portal: [PAS Stained Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=PAS+Stained+Microscopy&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/docs/ultrasound/index.md
+++ b/docs/ultrasound/index.md
@@ -15,6 +15,8 @@ This schema is for clinical imaging using ultrasound.
 
 
 
+In the portal: Ultrasound not in Portal
+
 ## Metadata schema
 
 ### Field types

--- a/docs/wgs/index.md
+++ b/docs/wgs/index.md
@@ -23,6 +23,8 @@ Related files:
 
 
 
+In the portal: [Whole Genome Sequencing](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Whole+Genome+Sequencing&entity_type%5B0%5D=Dataset)
+
 ## Metadata schema
 
 ### Field types

--- a/src/ingest_validation_tools/docs.template
+++ b/src/ingest_validation_tools/docs.template
@@ -15,6 +15,8 @@ ${optional_description_md}
 
 ${optional_dir_description_md}
 
+${optional_portal_names_md}
+
 ## Metadata schema
 
 ### Field types

--- a/src/ingest_validation_tools/docs_utils.py
+++ b/src/ingest_validation_tools/docs_utils.py
@@ -3,6 +3,9 @@ from string import Template
 from pathlib import Path
 import html
 from typing import Dict, Any
+from urllib.parse import urlencode
+
+import requests
 
 from ingest_validation_tools.schema_loader import get_field_enum, get_fields_wo_headers
 
@@ -87,6 +90,34 @@ def _enrich_description(field: Dict[str, Any]) -> str:
     return description.strip()
 
 
+def _get_portal_name(assay_type):
+    response = requests.post(
+        'https://search.api.hubmapconsortium.org/assayname',
+        json={'name': assay_type},
+        headers={'Content-Type': 'application/json'}
+    ).json()
+    try:
+        return response['description']
+    except KeyError as e:
+        return None
+
+
+def _get_portal_names_md(assay_types):
+    links = []
+    for assay_type in assay_types:
+        portal_name = _get_portal_name(assay_type)
+        if portal_name is None:
+            links.append(f'{assay_type} not in Portal')
+            continue
+        query = urlencode({
+            'mapped_data_types[0]': portal_name,
+            'entity_type[0]': 'Dataset'
+        })
+        url = f'https://portal.hubmapconsortium.org/search?{query}'
+        links.append(f'[{portal_name}]({url})')
+    return f'In the portal: {" / ".join(links)}'
+
+
 def generate_readme_md(
         table_schemas, pipeline_infos, directory_schemas, schema_name, is_assay=True):
     int_keys = [int(k) for k in table_schemas.keys()]
@@ -107,6 +138,8 @@ def generate_readme_md(
 
     raw_base_url = 'https://raw.githubusercontent.com/' \
         'hubmapconsortium/ingest-validation-tools/main/docs'
+
+    optional_portal_names_md = _get_portal_names_md(assay_type_enum) if assay_type_enum else ''
 
     optional_dir_description_md = (
         f'## Directory schemas\n{_make_dir_descriptions(directory_schemas, pipeline_infos)}'
@@ -162,6 +195,7 @@ def generate_readme_md(
                 for v in range(max_version - 1, min_version - 1, -1)
             ]),
 
+        'optional_portal_names_md': optional_portal_names_md,
         'optional_dir_description_md': optional_dir_description_md,
 
         'optional_doc_link_md': optional_doc_link_md,


### PR DESCRIPTION
- Fix #1118
- @ngehlenborg 
  - I think you wanted more clarity on how the assay names here relate to those in the portal. This attempts to provide that: Is it enough?
- @jswelling 
  -  A number of the names here aren't in the assay service... maybe we just haven't had any submissions of those, and so you haven't needed to make updates there?
  - Hitting the assay service at doc generation time does slow down the process a bit... is it worth having a local cache... or will that just add complexity?