### PR TITLE
Added note on documentation to address issue #1129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -478,3 +478,4 @@ If other patterns are given, dot-files must be explicitly ignored.
 - Define path fields only in one place.
 - Remove timezone offset.
 - Autogenerate parts of table schema.
+- New note to clarify git is required.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ src/validate_upload.py --help
 
 You should see [the documention for `validate_upload.py`](script-docs/README-validate_upload.py.md)
 
+**Note**: you need to have _git_ installed in your system.
+
 Now run it against one of the included examples, giving the path to an upload directory:
 ```
 src/validate_upload.py \


### PR DESCRIPTION
Users can download or get a copy of the code without using git and it is not clear that this is a required element for the validation to work. Related issue #1129 