### PR TITLE
Update to ErrorReport class to be backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Use the assay service to describe how assays are represented in the Portal.
 - Adding Comma Separated File support for tissue_id
 - Update assay type for Cell DIVE.
+- Creating extra_parameter on upload for future dynamic adding
 
 
 ## v0.0.14 - 2022-06-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 - Make `contributors_path` required for HCA.
 - Parallelize tests.
 - Use the assay service to describe how assays are represented in the Portal.
-- Adding Comma Separated File support for tissue_id
+- Adding Comma Separated File support for tissue_id.
 - Update assay type for Cell DIVE.
-- Creating extra_parameter on upload for future dynamic adding
+- Creating extra_parameter on upload for future dynamic adding.
+- Updated ErrorReport class to be backwards compatible with external calls.
 
 
 ## v0.0.14 - 2022-06-23

--- a/src/ingest_validation_tools/error_report.py
+++ b/src/ingest_validation_tools/error_report.py
@@ -10,7 +10,7 @@ Dumper.ignore_aliases = lambda *args: True
 
 
 class ErrorReport:
-    def __init__(self, info=None, errors=None):
+    def __init__(self, errors=None, info=None):
         self.info = info
         self.errors = errors
         if self.errors:

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -32,7 +32,7 @@ class Upload:
                  optional_fields=[], add_notes=True,
                  dataset_ignore_globs=[], upload_ignore_globs=[],
                  plugin_directory=None, encoding=None, offline=None,
-                 ignore_deprecation=False):
+                 ignore_deprecation=False, extra_parameters={}):
         self.directory_path = directory_path
         self.optional_fields = optional_fields
         self.dataset_ignore_globs = dataset_ignore_globs
@@ -44,6 +44,7 @@ class Upload:
         self.ignore_deprecation = ignore_deprecation
         self.errors = {}
         self.effective_tsv_paths = {}
+        self.extra_parameters = extra_parameters
         try:
             unsorted_effective_tsv_paths = {
                 str(path): get_table_schema_version(path, self.encoding)
@@ -93,6 +94,8 @@ class Upload:
         # This creates a deeply nested dict.
         # Keys are present only if there is actually an error to report.
         # plugin_kwargs are passed to the plugin validators.
+
+        kwargs.update(self.extra_parameters)
         if self.errors:
             return self.errors
 


### PR DESCRIPTION
This update will fix a problem with external calls to the class because of a mismatch order of parameters (issue #1145)