### PR TITLE
Restructure plugin_validator to provide an iterator of plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## v0.0.15 - in progress
+- Provide an iterator over plugin test classes
 - Updated CODEX version 0.
 - Added Bulk RNA-seq directory structure schema.
 - Added SeqFISH directory structure schema.

--- a/docs/af/index.md
+++ b/docs/af/index.md
@@ -27,7 +27,7 @@ This schema is for autofluorescence (AF). For an example of an AF dataset & dire
 
 
 
-In the portal: [Autofluorescence Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Autofluorescence+Microscopy&entity_type%5B0%5D=Dataset)
+In the portal: AF not in Portal
 
 ## Metadata schema
 

--- a/docs/bulkatacseq/index.md
+++ b/docs/bulkatacseq/index.md
@@ -24,7 +24,7 @@ This schema is for Assay for Transposase-Accessible Chromatin by sequencing (ATA
 
 
 
-In the portal: [Bulk ATAC-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Bulk+ATAC-seq&entity_type%5B0%5D=Dataset)
+In the portal: bulkATACseq not in Portal
 
 ## Metadata schema
 

--- a/docs/bulkrnaseq/index.md
+++ b/docs/bulkrnaseq/index.md
@@ -24,7 +24,7 @@ Related files:
 
 
 
-In the portal: [Bulk RNA-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Bulk+RNA-seq&entity_type%5B0%5D=Dataset)
+In the portal: bulk RNA not in Portal
 
 ## Metadata schema
 

--- a/docs/celldive/index.md
+++ b/docs/celldive/index.md
@@ -28,7 +28,7 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
-In the portal: [Cell DIVE](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Cell+DIVE&entity_type%5B0%5D=Dataset) / [Cell DIVE](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Cell+DIVE&entity_type%5B0%5D=Dataset)
+In the portal: Cell DIVE not in Portal / cell-dive not in Portal
 
 ## Metadata schema
 

--- a/docs/codex/index.md
+++ b/docs/codex/index.md
@@ -58,7 +58,7 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
-In the portal: [CODEX](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=CODEX&entity_type%5B0%5D=Dataset) / [CODEX (CODEX2 assay type)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=CODEX+%28CODEX2+assay+type%29&entity_type%5B0%5D=Dataset)
+In the portal: CODEX not in Portal / CODEX2 not in Portal
 
 ## Metadata schema
 

--- a/docs/imc/index.md
+++ b/docs/imc/index.md
@@ -25,7 +25,7 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
-In the portal: [Imaging Mass Cytometry (2D)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Imaging+Mass+Cytometry+%282D%29&entity_type%5B0%5D=Dataset)
+In the portal: Imaging Mass Cytometry not in Portal
 
 ## Metadata schema
 

--- a/docs/imc3d/index.md
+++ b/docs/imc3d/index.md
@@ -35,7 +35,7 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
-In the portal: [Imaging Mass Cytometry (3D)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Imaging+Mass+Cytometry+%283D%29&entity_type%5B0%5D=Dataset)
+In the portal: 3D Imaging Mass Cytometry not in Portal
 
 ## Metadata schema
 

--- a/docs/ims/index.md
+++ b/docs/ims/index.md
@@ -31,7 +31,7 @@ This schema is for imaging mass spectrometry (IMS).
 
 
 
-In the portal: [MALDI IMS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MALDI+IMS&entity_type%5B0%5D=Dataset) / SIMS-IMS not in Portal / [NanoDESI](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=NanoDESI&entity_type%5B0%5D=Dataset) / DESI not in Portal
+In the portal: MALDI-IMS not in Portal / SIMS-IMS not in Portal / NanoDESI not in Portal / DESI not in Portal
 
 ## Metadata schema
 

--- a/docs/lcms/index.md
+++ b/docs/lcms/index.md
@@ -29,7 +29,7 @@ v3 adds `dms` and `label_name` fields, and `negative and positive ion mode` as a
 
 
 
-In the portal: [LC-MS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=LC-MS&entity_type%5B0%5D=Dataset) / [MS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MS&entity_type%5B0%5D=Dataset) / [LC-MS Bottom Up](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=LC-MS+Bottom+Up&entity_type%5B0%5D=Dataset) / [MS Bottom Up](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MS+Bottom+Up&entity_type%5B0%5D=Dataset) / [LC-MS Top Down](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=LC-MS+Top+Down&entity_type%5B0%5D=Dataset) / [MS Top Down](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=MS+Top+Down&entity_type%5B0%5D=Dataset)
+In the portal: LC-MS not in Portal / MS not in Portal / LC-MS Bottom-Up not in Portal / MS Bottom-Up not in Portal / LC-MS Top-Down not in Portal / MS Top-Down not in Portal
 
 ## Metadata schema
 

--- a/docs/lightsheet/index.md
+++ b/docs/lightsheet/index.md
@@ -38,7 +38,7 @@ The other fields function the same way for all assays using antibodies. For more
 
 
 
-In the portal: [Lightsheet Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Lightsheet+Microscopy&entity_type%5B0%5D=Dataset)
+In the portal: Light Sheet not in Portal
 
 ## Metadata schema
 

--- a/docs/mibi/index.md
+++ b/docs/mibi/index.md
@@ -35,7 +35,7 @@ This schema is for Multiplex Ion Beam Imaging (MIBI). For MIBI, the channel_id (
 
 
 
-In the portal: [Multiplex Ion Beam Imaging](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Multiplex+Ion+Beam+Imaging&entity_type%5B0%5D=Dataset)
+In the portal: Multiplex Ion Beam Imaging not in Portal
 
 ## Metadata schema
 

--- a/docs/mxif/index.md
+++ b/docs/mxif/index.md
@@ -24,7 +24,7 @@ This schema is for multiplex immunofluorescence microscopy (MxIF).
 
 
 
-In the portal: [Multiplexed IF Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Multiplexed+IF+Microscopy&entity_type%5B0%5D=Dataset)
+In the portal: MxIF not in Portal
 
 ## Metadata schema
 

--- a/docs/nano/index.md
+++ b/docs/nano/index.md
@@ -31,7 +31,7 @@ Related files:
 
 
 
-In the portal: [NanoDESI](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=NanoDESI&entity_type%5B0%5D=Dataset) / [NanoPOTS](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=NanoPOTS&entity_type%5B0%5D=Dataset)
+In the portal: NanoDESI not in Portal / NanoPOTS not in Portal
 
 ## Metadata schema
 

--- a/docs/scatacseq/index.md
+++ b/docs/scatacseq/index.md
@@ -26,7 +26,7 @@ The HIVE will process each dataset with
 
 
 
-In the portal: [snATACseq (SNARE-seq2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snATACseq+%28SNARE-seq2%29&entity_type%5B0%5D=Dataset) / [sciATAC-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=sciATAC-seq&entity_type%5B0%5D=Dataset) / [snATAC-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snATAC-seq&entity_type%5B0%5D=Dataset)
+In the portal: SNARE-seq2 not in Portal / sciATACseq not in Portal / snATACseq not in Portal
 
 ## Metadata schema
 

--- a/docs/scrnaseq-hca/index.md
+++ b/docs/scrnaseq-hca/index.md
@@ -24,7 +24,7 @@ Related files:
 
 
 
-In the portal: [scRNA-seq (10x Genomics v2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=scRNA-seq+%2810x+Genomics+v2%29&entity_type%5B0%5D=Dataset) / [scRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=scRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v2%29&entity_type%5B0%5D=Dataset) / scRNAseq not in Portal / [sciRNA-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=sciRNA-seq&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / [snRNAseq (SNARE-seq2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNAseq+%28SNARE-seq2%29&entity_type%5B0%5D=Dataset)
+In the portal: scRNAseq-10xGenomics-v2 not in Portal / scRNAseq-10xGenomics-v3 not in Portal / snRNAseq-10xGenomics-v2 not in Portal / scRNAseq not in Portal / sciRNAseq not in Portal / snRNAseq not in Portal / SNARE2-RNAseq not in Portal
 
 ## Metadata schema
 

--- a/docs/scrnaseq/index.md
+++ b/docs/scrnaseq/index.md
@@ -24,7 +24,7 @@ This schema is for single cell RNA sequencing (scRNAseq). v3 adds `umi_*` fields
 
 
 
-In the portal: [scRNA-seq (10x Genomics v2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=scRNA-seq+%2810x+Genomics+v2%29&entity_type%5B0%5D=Dataset) / [scRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=scRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v2%29&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / scRNAseq not in Portal / [sciRNA-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=sciRNA-seq&entity_type%5B0%5D=Dataset) / [snRNA-seq (10x Genomics v3)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNA-seq+%2810x+Genomics+v3%29&entity_type%5B0%5D=Dataset) / [snRNAseq (SNARE-seq2)](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=snRNAseq+%28SNARE-seq2%29&entity_type%5B0%5D=Dataset)
+In the portal: scRNAseq-10xGenomics-v2 not in Portal / scRNAseq-10xGenomics-v3 not in Portal / snRNAseq-10xGenomics-v2 not in Portal / snRNAseq-10xGenomics-v3 not in Portal / scRNAseq not in Portal / sciRNAseq not in Portal / snRNAseq not in Portal / SNARE2-RNAseq not in Portal
 
 ## Metadata schema
 

--- a/docs/seqfish/index.md
+++ b/docs/seqfish/index.md
@@ -36,7 +36,7 @@ This schema is for spatial sequencing by fluorescence in situ hybridization (seq
 
 
 
-In the portal: [seqFISH](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=seqFISH&entity_type%5B0%5D=Dataset)
+In the portal: seqFISH not in Portal
 
 ## Metadata schema
 

--- a/docs/slideseq/index.md
+++ b/docs/slideseq/index.md
@@ -35,7 +35,7 @@ Related files:
 
 
 
-In the portal: [Slide-seq](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Slide-seq&entity_type%5B0%5D=Dataset)
+In the portal: Slide-seq not in Portal
 
 ## Metadata schema
 

--- a/docs/stained/index.md
+++ b/docs/stained/index.md
@@ -27,7 +27,7 @@ This schema is for microscopy of tissue treated with periodic acid–Schiff stai
 
 
 
-In the portal: [PAS Stained Microscopy](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=PAS+Stained+Microscopy&entity_type%5B0%5D=Dataset)
+In the portal: PAS microscopy not in Portal
 
 ## Metadata schema
 

--- a/docs/wgs/index.md
+++ b/docs/wgs/index.md
@@ -24,7 +24,7 @@ Related files:
 
 
 
-In the portal: [Whole Genome Sequencing](https://portal.hubmapconsortium.org/search?mapped_data_types%5B0%5D=Whole+Genome+Sequencing&entity_type%5B0%5D=Dataset)
+In the portal: WGS not in Portal
 
 ## Metadata schema
 


### PR DESCRIPTION
In the base branch plugin_validator provides an iterator over error strings discovered by plugin validators.  This PR restructures that iterator.  The new version provides an iterator over the plugin classes, and the original iterator is rewritten to use the new iterator.