### PR TITLE
Revert "Bump tzinfo from 1.2.9 to 1.2.10 in /docs"

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.10)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
Reverts hubmapconsortium/ingest-validation-tools#1125