### PR TITLE
Versioning of stained directory structure schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## v0.0.15 - in progress
+- Versioned directory structure schema
 - Added Lightsheet version 1.
 - bump nokogiri -> 1.13.9 (dependabot)
 - Add front-matter to exclude HCA from toc

--- a/docs/stained/index.md
+++ b/docs/stained/index.md
@@ -15,7 +15,7 @@ Related files:
 This schema is for microscopy of tissue treated with periodic acid–Schiff stain (stained). For an example of a PAS (Periodic acid-Schiff) dataset & directory, see this [example PAS stained dataset](https://portal.hubmapconsortium.org/browse/dataset/7308530b92438fdbe258b501aeb86069#files) and click the Globus link.
 
 ## Directory schemas
-### v0
+### v1
 
 | pattern | required? | description |
 | --- | --- | --- |
@@ -23,6 +23,16 @@ This schema is for microscopy of tissue treated with periodic acid–Schiff stai
 | <code>(processedMicroscopy&#124;processed_microscopy)/[^/]+_transformations/[^/]+\.txt</code> |  | Transformations to PAS (related) data |
 | <code>(rawMicroscopy&#124;raw_microscopy)/[^/]+\.xml</code> | ✓ | XML metadata file from the autofluorescence microscopy experiments |
 | <code>(rawMicroscopy&#124;raw_microscopy)/[^/]+\.(scn&#124;czi&#124;tif&#124;tiff)</code> | ✓ | Raw microscope file for the experiment |
+| <code>extras/.*</code> |  | Free-form descriptive information supplied by the TMC |
+
+### v0
+
+| pattern | required? | description |
+| --- | --- | --- |
+| <code>(processedMicroscopy&#124;processed_microscopy)/[^/]+_images/[^/]+ome\.(tif&#124;tiff)</code> | ✓ | OME TIFF files (multichannel, multi-layered, image pyramids) produced by the PAS microscopy experiment |
+| <code>(processedMicroscopy&#124;processed_microscopy)/[^/]+_transformations/[^/]+\.txt</code> |  | Transformations to PAS (related) data |
+| <code>(rawMicroscopy&#124;raw_microscopy)/[^/]+\.xml</code> | ✓ | XML metadata file from the autofluorescence microscopy experiments |
+| <code>(rawMicroscopy&#124;raw_microscopy)/[^/]+\.scn</code> | ✓ | Raw microscope file for the experiment |
 | <code>extras/.*</code> |  | Free-form descriptive information supplied by the TMC |
 
 

--- a/src/ingest_validation_tools/directory-schemas/stained-v1.yaml
+++ b/src/ingest_validation_tools/directory-schemas/stained-v1.yaml
@@ -17,5 +17,5 @@ files:
   # Leica .scn which is a container with tiled scan images (bigtiff)
   # which is the only type that we are currently receiving.
   -
-    pattern: '(rawMicroscopy|raw_microscopy)/[^/]+\.scn'
+    pattern: '(rawMicroscopy|raw_microscopy)/[^/]+\.(scn|czi|tif|tiff)'
     description: 'Raw microscope file for the experiment'


### PR DESCRIPTION
This is a hotfix for the [PR](https://github.com/hubmapconsortium/ingest-validation-tools/pull/1164).

Instead of updating the version 0 of the directory structure schema we should have created version 1.