### PR TITLE
adding ReportType logic from SenNet, updating to allow for CEDAR validation as well

### DIFF
--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -28,6 +28,7 @@ class add_path:
         sys.path.insert(0, self.path)
 
     def __exit__(self, exc_type, exc_value, traceback):
+        del exc_type, exc_value, traceback
         try:
             sys.path.remove(self.path)
         except ValueError:
@@ -58,7 +59,7 @@ class Validator(object):
             raise ValidatorError(f"{self.path} is not a directory")
         self.assay_type = assay_type
 
-    def collect_errors(self, **kwargs) -> List[str]:
+    def collect_errors(self) -> List[str]:
         """
         Returns a list of strings, each of which is a
         human-readable error message.
@@ -83,6 +84,7 @@ def run_plugin_validators_iter(
 
     returns an iterator the values of which are key value pairs representing error messages.
     """
+
     metadata_path = Path(metadata_path)
     if metadata_path.is_file():
         try:
@@ -150,7 +152,7 @@ def validation_class_iter(plugin_dir: PathOrStr) -> Iterator[Type[Validator]]:
                 mod = util.module_from_spec(spec)
                 sys.modules[mod_nm] = mod
                 spec.loader.exec_module(mod)  # type: ignore
-            for name, obj in inspect.getmembers(mod):
+            for _, obj in inspect.getmembers(mod):
                 if (
                     inspect.isclass(obj)
                     and obj != Validator
@@ -158,7 +160,7 @@ def validation_class_iter(plugin_dir: PathOrStr) -> Iterator[Type[Validator]]:
                 ):
                     sort_me.append((obj.cost, obj.description, obj))
     sort_me.sort()
-    for cost, description, cls in sort_me:
+    for _, _, cls in sort_me:
         yield cls
 
 

--- a/src/ingest_validation_tools/table_validator.py
+++ b/src/ingest_validation_tools/table_validator.py
@@ -1,40 +1,46 @@
 import csv
 from pathlib import Path
 from typing import List, Optional, Dict, Union
+from enum import Enum
 
 import frictionless
 
-
 from ingest_validation_tools.check_factory import make_checks
+from ingest_validation_tools.validation_utils import get_json
 
 
-def get_table_errors(tsv: Union[Path, str], schema: dict) -> List[str]:
+class ReportType(Enum):
+    STR = 1
+    JSON = 2
+
+
+def get_table_errors(
+    tsv: Union[Path, str], schema: dict, report_type: ReportType = ReportType.STR
+) -> List:
     tsv_path = Path(tsv)
     pre_flight_errors = _get_pre_flight_errors(tsv_path, schema=schema)
     if pre_flight_errors:
         return pre_flight_errors
 
-    assert frictionless.__version__ == '4.0.0',\
-        'Upgrade dependencies: "pip install -r requirements.txt"'
+    # assert (
+    #     frictionless.__version__ == "4.0.0"
+    # ), 'Upgrade dependencies: "pip install -r requirements.txt"'
 
     report = frictionless.validate(
-        tsv_path, schema=schema,
-        format='csv',
-        checks=make_checks(schema)
+        tsv_path, schema=schema, format="csv", checks=make_checks(schema)
     )
 
-    assert len(report['errors']) == 0, f'report has errors: {report}'
-    assert 'tasks' in report, f'"tasks" is missing: {report}'
-    tasks = report['tasks']
+    assert len(report["errors"]) == 0, f"report has errors: {report}"
+    assert "tasks" in report, f'"tasks" is missing: {report}'
+    tasks = report["tasks"]
     assert len(tasks) == 1, f'"tasks" not single: {report}'
     task = tasks[0]
-    assert 'errors' in task, f'"tasks" missing "errors": {report}'
+    assert "errors" in task, f'"tasks" missing "errors": {report}'
 
-    schema_fields_dict = {field['name']: field for field in schema['fields']}
+    schema_fields_dict = {field["name"]: field for field in schema["fields"]}
 
     return [
-        _get_message(error, schema_fields_dict)
-        for error in task['errors']
+        _get_message(error, schema_fields_dict, report_type) for error in task["errors"]
     ]
 
 
@@ -44,15 +50,17 @@ def _get_pre_flight_errors(tsv_path: Path, schema: dict) -> Optional[List[str]]:
     except csv.Error as e:
         return [str(e)]
     delimiter = dialect.delimiter
-    expected_delimiter = '\t'
+    expected_delimiter = "\t"
     if delimiter != expected_delimiter:
-        return [f'Delimiter is {repr(delimiter)}, rather than expected {repr(expected_delimiter)}']
+        return [
+            f"Delimiter is {repr(delimiter)}, rather than expected {repr(expected_delimiter)}"
+        ]
 
     # Re-reading the file is ugly, but creating a stream seems gratuitous.
     with tsv_path.open() as tsv_handle:
         reader = csv.DictReader(tsv_handle, dialect=dialect)
         fields = reader.fieldnames or []
-        expected_fields = [f['name'] for f in schema['fields']]
+        expected_fields = [f["name"] for f in schema["fields"]]
         if fields != expected_fields:
             errors = []
             fields_set = set(fields)
@@ -60,22 +68,28 @@ def _get_pre_flight_errors(tsv_path: Path, schema: dict) -> Optional[List[str]]:
             extra_fields = fields_set - expected_fields_set
 
             if extra_fields:
-                errors.append(f'Unexpected fields: {extra_fields}')
+                errors.append(f"Unexpected fields: {extra_fields}")
             missing_fields = expected_fields_set - fields_set
             if missing_fields:
-                errors.append(f'Missing fields: {missing_fields}')
+                errors.append(f"Missing fields: {missing_fields}")
 
             for i_pair in enumerate(zip(fields, expected_fields)):
                 i, (actual, expected) = i_pair
                 if actual != expected:
-                    errors.append(f'In column {i+1}, found "{actual}", expected "{expected}"')
+                    errors.append(
+                        f'In column {i+1}, found "{actual}", expected "{expected}"'
+                    )
             return errors
 
     return None
 
 
-def _get_message(error: Dict[str, str], schema_fields: Dict[str, dict]) -> str:
-    '''
+def _get_message(
+    error: Dict[str, str],
+    schema_fields: Dict[str, dict],
+    report_type: ReportType = ReportType.STR,
+) -> Union[str, Dict]:
+    """
     >>> print(_get_message(
     ... {
     ...     'cell': 'bad-id',
@@ -97,29 +111,41 @@ def _get_message(error: Dict[str, str], schema_fields: Dict[str, dict]) -> str:
     On row 2, column "orcid_id", value "bad-id" fails because\
  constraint "pattern" is "fake-re". Example: real-re
 
-    '''
+    """
 
     example = schema_fields.get(error.get("fieldName", ""), {}).get("example", "")
 
-    if 'code' in error and error['code'] == 'missing-label':
-        return 'Bug: Should have been caught pre-flight. File an issue.'
-    if 'rowPosition' in error and 'fieldName' in error and 'cell' in error and 'note' in error:
-        return (
+    return_str = report_type is ReportType.STR
+    if "code" in error and error["code"] == "missing-label":
+        msg = "Bug: Should have been caught pre-flight. File an issue."
+        return msg if return_str else get_json(msg)
+    if (
+        "rowPosition" in error
+        and "fieldName" in error
+        and "cell" in error
+        and "note" in error
+    ):
+        msg = (
             f'On row {error["rowPosition"]}, column "{error["fieldName"]}", '
             f'value "{error["cell"]}" fails because {error["note"]}'
             f'{f". Example: {example}" if example else example}'
         )
-    return error['message']
+        return (
+            msg
+            if return_str
+            else get_json(msg, error["rowPosition"], error["fieldName"])
+        )
+    return error["message"]
 
 
 if __name__ == "__main__":
     import argparse
     from yaml import safe_load
 
-    parser = argparse.ArgumentParser('CLI just for testing')
-    parser.add_argument('--fixture', type=Path, required=True)
+    parser = argparse.ArgumentParser("CLI just for testing")
+    parser.add_argument("--fixture", type=Path, required=True)
     args = parser.parse_args()
-    tsv_path = args.fixture / 'input.tsv'
-    schema_path = args.fixture / 'schema.yaml'
+    tsv_path = args.fixture / "input.tsv"
+    schema_path = args.fixture / "schema.yaml"
     errors = get_table_errors(tsv_path, safe_load(schema_path.read_text()))
-    print('\n'.join(errors))
+    print("\n".join(errors))


### PR DESCRIPTION
Changes directly from SenNet:
- table_validator.py
- validation_utils.py > get_tsv_errors

Updates to integrate CEDAR validation:
- validation_utils.py > get_tsv_errors updated to route through CEDAR validation in a metadata_schema_id is present; it's done this way because of the way [ingest-api expects to receive this data](https://github.com/sennetconsortium/ingest-api/blob/6a6d7bf5b5d08b6d85b0eb75bdc889c58bf075fc/src/routes/validation/validation.py#L64)
- upload.py updated with custom _get_message method
- validation_utils.py > get_json added