### PR TITLE
testing fix for finding dir schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Bugfix datetime constraint in library_creation_date.yaml
 - Update LCMS and add NanoSplits
 - Update descriptions for segmentation masks
+- Bugfix for directory schema location
 
 ## v0.0.15 - 2023-04-04
 

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -384,14 +384,19 @@ class Upload:
         schema_name = schema_version.schema_name
 
         if "sample" in schema_name:
-            constrained_fields['sample_id'] = "https://entity.api.hubmapconsortium.org/entities/"
+            constrained_fields[
+                "sample_id"
+            ] = "https://entity.api.hubmapconsortium.org/entities/"
         elif "organ" in schema_name:
-            constrained_fields['organ_id'] = "https://entity.api.hubmapconsortium.org/entities/"
+            constrained_fields[
+                "organ_id"
+            ] = "https://entity.api.hubmapconsortium.org/entities/"
         elif "contributors" in schema_name:
-            constrained_fields['orcid_id'] = "https://pub.orcid.org/v3.0/"
+            constrained_fields["orcid_id"] = "https://pub.orcid.org/v3.0/"
         else:
-            constrained_fields['parent_sample_id'] = \
-                "https://entity.api.hubmapconsortium.org/entities/"
+            constrained_fields[
+                "parent_sample_id"
+            ] = "https://entity.api.hubmapconsortium.org/entities/"
 
         url_errors = self._check_matching_urls(tsv_path, constrained_fields)
         if url_errors:
@@ -490,6 +495,7 @@ class Upload:
         schema_name: str,
         schema_version: str,
         metadata_path: Union[str, Path],
+        is_cedar: bool = False,
     ) -> Optional[Dict]:
         errors: Dict[
             str, Union[list, dict]
@@ -500,6 +506,7 @@ class Upload:
                 path,
                 schema_version,
                 dataset_ignore_globs=self.dataset_ignore_globs,
+                is_cedar=is_cedar,
             )
             if ref_errors:
                 # TODO: quote field name to match TSV error output;
@@ -512,7 +519,7 @@ class Upload:
                 offline=self.offline,
                 encoding=self.encoding,
                 ignore_deprecation=self.ignore_deprecation,
-                cedar_api_key=self.cedar_api_key
+                cedar_api_key=self.cedar_api_key,
             )
             # TSV located and read, errors found
             if tsv_ref_errors and isinstance(tsv_ref_errors, list):
@@ -547,6 +554,10 @@ class Upload:
             if not row.get(field):
                 continue
             data_path = self.directory_path / row[field]
+            if "metadata_schema_id" in rows[0]:
+                is_cedar = True
+            else:
+                is_cedar = False
             ref_error = self._check_path(
                 i,
                 data_path,
@@ -554,6 +565,7 @@ class Upload:
                 schema.schema_name,
                 schema.version,
                 metadata_path,
+                is_cedar=is_cedar,
             )
             if ref_error:
                 ref_errors.update(ref_error)
@@ -566,9 +578,7 @@ class Upload:
             | set(self.__get_antibodies_references().keys())
         )
 
-        referenced_data_paths = {
-            Path(path) for path in referenced_data_paths
-        }
+        referenced_data_paths = {Path(path) for path in referenced_data_paths}
 
         non_metadata_paths = {
             Path(path.name)

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -68,19 +68,21 @@ def _read_rows(path, encoding: str):
     return rows
 
 
-def _get_directory_schema_version(data_path: str, schema_version: str) -> str:
+def _get_directory_schema_version(
+    data_path: str, schema_version: str, is_cedar: bool = False
+) -> str:
     prefix = "dir-schema-v"
     version_hints = [
         path.name for path in (Path(data_path) / "extras").glob(f"{prefix}*")
     ]
     len_hints = len(version_hints)
-    # CEDAR schemas are all v2+; if no hints are provided, default to
+    # CEDAR schemas: if no hints are provided, default to
     # data directory schema v2
-    if len_hints == 0 and int(schema_version) > 1:
+    if len_hints == 0 and is_cedar:
         return "2"
     # For non-CEDAR templates, default to data directory schema v0 if
     # no hints provided
-    elif len_hints == 0:
+    elif len_hints == 0 and not is_cedar:
         return "0"
     elif len_hints == 1:
         return version_hints[0].replace(prefix, "")
@@ -92,12 +94,15 @@ def get_data_dir_errors(
     schema_name: str,
     data_path: Path,
     schema_version: str,
+    is_cedar: bool,
     dataset_ignore_globs: List[str] = [],
 ) -> Optional[dict]:
     """
     Validate a single data_path.
     """
-    schema_version = _get_directory_schema_version(str(data_path), schema_version)
+    schema_version = _get_directory_schema_version(
+        str(data_path), schema_version, is_cedar
+    )
     return _get_data_dir_errors_for_version(
         schema_name, data_path, dataset_ignore_globs, schema_version
     )


### PR DESCRIPTION
This code was making a bad assumption (that all non-CEDAR schema versions were v0 or v1). This fix passes an is_cedar arg down to `validation_utils > _get_directory_schema_version` so that the determination of CEDAR vs. not-CEDAR is smarter. This still assumes that dir-schema versions are v0 (unless there is a hint in the `extras` directory) for non-CEDAR datasets and v2 (same caveat about hints) for CEDAR datasets. This is imprecise and asking for trouble and should be fixed with the soft assay types integration.