### PR TITLE
Bail before running plugins if other errors are detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Update LCMS and add NanoSplits
 - Update descriptions for segmentation masks
 - Add description to codex doc page
+- Bail earlier in validation if there are errors in metadata/dir/refs
 
 ## v0.0.15 - 2023-04-04
 

--- a/script-docs/README-validate_upload.py.md
+++ b/script-docs/README-validate_upload.py.md
@@ -6,8 +6,7 @@ usage: validate_upload.py [-h] --local_directory PATH
                           [--upload_ignore_globs GLOB [GLOB ...]]
                           [--encoding ENCODING]
                           [--plugin_directory PLUGIN_DIRECTORY]
-                          [--skip_plugins_if_errors SKIP_PLUGINS_IF_ERRORS]
-                          [--globus_token GLOBUS_TOKEN]
+                          [--run_plugins] [--globus_token GLOBUS_TOKEN]
                           [--cedar_api_key CEDAR_API_KEY]
                           [--output {as_md,as_text,as_text_list,as_yaml}]
                           [--add_notes] [--save_report]
@@ -38,8 +37,8 @@ optional arguments:
                         tools/issues/494
   --plugin_directory PLUGIN_DIRECTORY
                         Directory of plugin tests.
-  --skip_plugins_if_errors SKIP_PLUGINS_IF_ERRORS
-                        If there are upstream errors, skip plugin validation.
+  --run_plugins         Run plugin validation even if there are upstream
+                        errors.
   --globus_token GLOBUS_TOKEN
                         Token for URL checking using Entity API.
   --cedar_api_key CEDAR_API_KEY

--- a/script-docs/README-validate_upload.py.md
+++ b/script-docs/README-validate_upload.py.md
@@ -6,6 +6,7 @@ usage: validate_upload.py [-h] --local_directory PATH
                           [--upload_ignore_globs GLOB [GLOB ...]]
                           [--encoding ENCODING]
                           [--plugin_directory PLUGIN_DIRECTORY]
+                          [--skip_plugins_if_errors SKIP_PLUGINS_IF_ERRORS]
                           [--globus_token GLOBUS_TOKEN]
                           [--cedar_api_key CEDAR_API_KEY]
                           [--output {as_md,as_text,as_text_list,as_yaml}]
@@ -37,6 +38,8 @@ optional arguments:
                         tools/issues/494
   --plugin_directory PLUGIN_DIRECTORY
                         Directory of plugin tests.
+  --skip_plugins_if_errors SKIP_PLUGINS_IF_ERRORS
+                        If there are upstream errors, skip plugin validation.
   --globus_token GLOBUS_TOKEN
                         Token for URL checking using Entity API.
   --cedar_api_key CEDAR_API_KEY

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -38,7 +38,6 @@ class ErrorDictException(Exception):
     def __init__(self, errors):
         message = f"Halting compilation of errors after detecting the following errors: {errors}."
         super().__init__(message)
-        # This returns only the error that caused the exception.
         labeled_errors = {}
         labeled_errors["Fatal Exception"] = errors
         self.errors = labeled_errors
@@ -157,6 +156,14 @@ class Upload:
             reference_errors = self._get_reference_errors()
             if reference_errors:
                 errors["Reference Errors"] = reference_errors
+
+            if errors:
+                raise ErrorDictException(
+                    f"""
+                                         Detected errors in upload metadata or directory structure.
+                                         Not moving on to plugin validation.
+                                         """
+                )
 
             plugin_errors = self._get_plugin_errors(**kwargs)
             if plugin_errors:

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -159,10 +159,7 @@ class Upload:
 
             if errors:
                 raise ErrorDictException(
-                    f"""
-                                         Detected errors in upload metadata or directory structure.
-                                         Not moving on to plugin validation.
-                                         """
+                    f"Skipping plugins validation: errors in upload metadata or dir structure."
                 )
 
             plugin_errors = self._get_plugin_errors(**kwargs)

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -59,7 +59,7 @@ class Upload:
         extra_parameters: Union[dict, None] = None,
         globus_token: str = "",
         cedar_api_key: str = "",
-        skip_plugins_if_errors: bool = False,
+        run_plugins: bool = False,
     ):
         self.directory_path = directory_path
         self.optional_fields = optional_fields
@@ -75,7 +75,7 @@ class Upload:
         self.extra_parameters = extra_parameters if extra_parameters else {}
         self.auth_tok = globus_token
         self.cedar_api_key = cedar_api_key
-        self.skip_plugins_if_errors = skip_plugins_if_errors
+        self.run_plugins = run_plugins
 
         try:
             unsorted_effective_tsv_paths = {
@@ -159,7 +159,7 @@ class Upload:
             if reference_errors:
                 errors["Reference Errors"] = reference_errors
 
-            if self.skip_plugins_if_errors and errors:
+            if errors and not self.run_plugins:
                 raise ErrorDictException(
                     "Skipping plugins validation: errors in upload metadata or dir structure."
                 )

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -59,6 +59,7 @@ class Upload:
         extra_parameters: Union[dict, None] = None,
         globus_token: str = "",
         cedar_api_key: str = "",
+        skip_plugins_if_errors: bool = False,
     ):
         self.directory_path = directory_path
         self.optional_fields = optional_fields
@@ -74,6 +75,7 @@ class Upload:
         self.extra_parameters = extra_parameters if extra_parameters else {}
         self.auth_tok = globus_token
         self.cedar_api_key = cedar_api_key
+        self.skip_plugins_if_errors = skip_plugins_if_errors
 
         try:
             unsorted_effective_tsv_paths = {
@@ -157,9 +159,9 @@ class Upload:
             if reference_errors:
                 errors["Reference Errors"] = reference_errors
 
-            if errors:
+            if self.skip_plugins_if_errors and errors:
                 raise ErrorDictException(
-                    f"Skipping plugins validation: errors in upload metadata or dir structure."
+                    "Skipping plugins validation: errors in upload metadata or dir structure."
                 )
 
             plugin_errors = self._get_plugin_errors(**kwargs)

--- a/src/validate_upload.py
+++ b/src/validate_upload.py
@@ -108,6 +108,11 @@ Exit status codes:
     parser.add_argument(
         "--plugin_directory", action="store", help="Directory of plugin tests."
     )
+    parser.add_argument(
+        "--skip_plugins_if_errors",
+        required=False,
+        help="If there are upstream errors, skip plugin validation.",
+    )
 
     # Arguments for manual tests
     parser.add_argument(
@@ -170,6 +175,7 @@ def main():
         "cedar_api_key": args.cedar_api_key,
         "optional_fields": args.optional_fields,
         "ignore_deprecation": args.ignore_deprecation,
+        "skip_plugins_if_errors": args.skip_plugins_if_errors,
     }
 
     if args.local_directory:
@@ -181,6 +187,8 @@ def main():
         upload_args["upload_ignore_globs"] = args.upload_ignore_globs
     if args.plugin_directory:
         upload_args["plugin_directory"] = args.plugin_directory
+    if args.skip_plugins_if_errors:
+        upload_args["skip_plugins_if_errors"] = args.skip_plugins_if_errors
     if args.globus_token:
         upload_args["globus_token"] = args.globus_token
     if args.cedar_api_key:

--- a/src/validate_upload.py
+++ b/src/validate_upload.py
@@ -109,9 +109,10 @@ Exit status codes:
         "--plugin_directory", action="store", help="Directory of plugin tests."
     )
     parser.add_argument(
-        "--skip_plugins_if_errors",
+        "--run_plugins",
         required=False,
-        help="If there are upstream errors, skip plugin validation.",
+        action="store_true",
+        help="Run plugin validation even if there are upstream errors.",
     )
 
     # Arguments for manual tests
@@ -175,7 +176,7 @@ def main():
         "cedar_api_key": args.cedar_api_key,
         "optional_fields": args.optional_fields,
         "ignore_deprecation": args.ignore_deprecation,
-        "skip_plugins_if_errors": args.skip_plugins_if_errors,
+        "run_plugins": args.run_plugins,
     }
 
     if args.local_directory:
@@ -187,8 +188,8 @@ def main():
         upload_args["upload_ignore_globs"] = args.upload_ignore_globs
     if args.plugin_directory:
         upload_args["plugin_directory"] = args.plugin_directory
-    if args.skip_plugins_if_errors:
-        upload_args["skip_plugins_if_errors"] = args.skip_plugins_if_errors
+    if args.run_plugins:
+        upload_args["run_plugins"] = args.run_plugins
     if args.globus_token:
         upload_args["globus_token"] = args.globus_token
     if args.cedar_api_key:

--- a/tests-manual/test-dataset-examples-cedar.sh
+++ b/tests-manual/test-dataset-examples-cedar.sh
@@ -10,7 +10,7 @@ for SUITE in examples/dataset-examples; do
 
     case ${SUITE} in
         examples/dataset-examples)
-            OPTS="--dataset_ignore_globs 'ignore-*.tsv' '.*' --globus_token ${GLOBUS_TOKEN} --cedar_api_key ${CEDAR_API_KEY} --upload_ignore_globs 'drv_ignore_*' --output as_md"
+            OPTS="--dataset_ignore_globs 'ignore-*.tsv' '.*' --run_plugins --globus_token ${GLOBUS_TOKEN} --cedar_api_key ${CEDAR_API_KEY} --upload_ignore_globs 'drv_ignore_*' --output as_md"
             ;;
         *)
             die "Unexpected ${SUITE}"

--- a/tests/test-dataset-examples.sh
+++ b/tests/test-dataset-examples.sh
@@ -7,12 +7,12 @@ for SUITE in examples/dataset-examples examples/dataset-iec-examples; do
 
     case $SUITE in
         examples/dataset-iec-examples)
-            OPTS="--dataset_ignore_globs 'metadata.tsv' --upload_ignore_globs '*'"
+            OPTS="--dataset_ignore_globs 'metadata.tsv' --upload_ignore_globs '*' --run_plugins"
             ;;
         examples/dataset-examples)
             # To minimize dependence on outside resources, --offline used here,
             # but ID lookup is still exercised by iec-examples.
-            OPTS="--dataset_ignore_globs 'ignore-*.tsv' '.*' --upload_ignore_globs 'drv_ignore_*' 'README_ONLINE' --offline --output as_md"
+            OPTS="--dataset_ignore_globs 'ignore-*.tsv' '.*' --upload_ignore_globs 'drv_ignore_*' 'README_ONLINE' --offline --run_plugins --output as_md"
             ;;
         *)
             die "Unexpected $SUITE"


### PR DESCRIPTION
Added logic to upload.py to throw a fatal exception in `get_errors` if errors are detected prior to running plugins in order to allow upstream errors to be corrected sooner.

Added an arg to `Upload` that toggles this skip setting to true by default, but it is turned off for testing in order to make it easier to detect all errors. 

Note: change to `directory_validator.py` is linting-only.