### PR TITLE
validate_upload.py documentation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Fix to support display of errors for CEDAR template metadata
 - Upate Auto-fluorescence, Confocal, and Light Sheet directory schemas
 - Additional updates to next-gen histology directory schema
+- Updated README.md to include changes to validate_upload.py
 
 ## v0.0.15 - 2023-04-04
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ HuBMAP data upload guidelines and tools which check that uploads adhere to those
 Assay documentation is on [Github Pages](https://hubmapconsortium.github.io/ingest-validation-tools/).
 
 HuBMAP has three distinct metadata processes:
-
 - **Donor** metadata is handled by Jonathan Silverstein on an adhoc basis: He works with whatever format the TMC can provide, and aligns it with controlled vocabularies.
 - **Sample** metadata is handled by Brendan Honick and Bill Shirey. [The standard operating procedure is outlined here.](https://docs.google.com/document/d/1K-PvBaduhrN-aU-vzWd9gZqeGvhGF3geTwRR0ww74Jo/edit)
 - **Dataset** uploads should be validated first by the TMCs. Dataset upload validation is the focus of this repo. [Details below.](#upload-process-and-upload-directory-structure)
@@ -12,14 +11,12 @@ HuBMAP has three distinct metadata processes:
 ## For assay type working groups:
 
 Before we can write code to validate a particular assay type, there are some prerequisites:
-
 - A document describing the experimental techniques involved.
 - A list of the metadata fields for this type, along with descriptions and constraints.
 - A list of the files to be expected in each dataset directory, along with descriptions.
   [Suggestions for describing directories](HOWTO-describe-directories.md).
 
 When all the parts are finalized,
-
 - The document will be translated into markdown, and added [here](https://github.com/hubmapconsortium/portal-docs/tree/main/assays).
 - The list of fields will be translated into a table schema, like those [here](src/ingest_validation_tools/table-schemas).
 - The list of files will be translated into a directory schema, like those [here](src/ingest_validation_tools/directory-schemas).
@@ -49,7 +46,6 @@ To validate your `*-metadata.tsv`, `contributors.tsv`, and `antibodies.tsv` file
 ### Validate directory structure
 
 Checkout the repo and install dependencies:
-
 ```
 python --version  # Should be Python3.
 git clone https://github.com/hubmapconsortium/ingest-validation-tools.git
@@ -64,7 +60,6 @@ You should see [the documention for `validate_upload.py`](script-docs/README-val
 **Note**: you need to have _git_ installed in your system.
 
 Now run it against one of the included examples, giving the path to an upload directory:
-
 ```
 src/validate_upload.py \
   --local_directory examples/dataset-examples/bad-tsv-formats/upload \
@@ -74,7 +69,6 @@ src/validate_upload.py \
 
 You should now see [this (extensive) error message](examples/dataset-examples/bad-tsv-formats/README.md).
 This example TSV has been constructed with a mistake in every column, just to demonstrate the checks which are available. Hopefully, more often your experience will be like this:
-
 ```
 src/validate_upload.py \
   --local_directory examples/dataset-examples/good-codex-akoya-directory-v1-with-dataset.json/upload \
@@ -113,7 +107,6 @@ src/validate_upload.py \
 ## For developers and contributors:
 
 An example of the core error-reporting functionality underlying `validate-upload.py`:
-
 ```python
 upload = Upload(directory_path=path)
 report = ErrorReport(upload.get_errors())
@@ -136,7 +129,6 @@ After making tweaks to the schema, you will need to regenerate the docs:
 The test error message will tell you what to do.
 
 For releases we're just using git tags:
-
 ```
 $ git tag v0.0.x
 $ git push origin v0.0.x
@@ -147,7 +139,6 @@ $ git push origin v0.0.x
 [![Repo structure](https://docs.google.com/drawings/d/e/2PACX-1vQ8gorGI8ceYBf0bIJQlw4HvI3ooVTvCfickHhCvGJU4yy5kViJI39oqQ7xB20WLYxv8FMRuBLGwmH-/pub?w=600)](https://docs.google.com/drawings/d/1UK81oUHTSHetGXRsA-YeSFS-kb6Nw2rNpnw8SBysYXU/edit)
 
 Checking in the built documentation is not the typical approach, but has worked well for this project:
-
 - It's a sanity check when making schema changes. Since the schema for an assay actually comes for multiple sources, having the result of include resolution checked in makes it possible to catch unintended changes.
 - It simplifies administration, since a separate static documentation site is not required.
 - It enables easy review of the history of a schema, since the usual git/github tools can be used.
@@ -155,7 +146,6 @@ Checking in the built documentation is not the typical approach, but has worked 
 ## Upload process and upload directory structure
 
 Data upload to HuBMAP is composed of discrete phases:
-
 - Upload preparation and validation
 - Upload and re-validation
 - Restructuring
@@ -164,7 +154,6 @@ Data upload to HuBMAP is composed of discrete phases:
 [![Upload process](https://docs.google.com/drawings/d/e/2PACX-1vSlMUKk0QU1bboxbT3x6gEMRawZDjZH_PWma2ZKVsnqlIDaCg3OFKq2zQg9dW_2ty8U3Z4UEENhUMvR/pub?w=1000)](https://docs.google.com/drawings/d/1fDhORYm8DYnCnbvpIrMMN0OxFQakHir_Ss071q2ySNc/edit)
 
 Uploads are based on directories containing at a minimum:
-
 - one or more `*-metadata.tsv` files.
 - top-level dataset directories in a 1-to-1 relationship with the rows of the TSVs.
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # ingest-validation-tools
-HuBMAP data upload guidelines, and tools which check that uploads adhere to those guidelines.
+
+HuBMAP data upload guidelines and tools which check that uploads adhere to those guidelines.
 Assay documentation is on [Github Pages](https://hubmapconsortium.github.io/ingest-validation-tools/).
 
 HuBMAP has three distinct metadata processes:
-- **Donor** metadata is handled by Jonathan Silverstein on an adhoc basis: He works with whatever format the TMC can provide, and aligns it with controlled vocabularies. 
+
+- **Donor** metadata is handled by Jonathan Silverstein on an adhoc basis: He works with whatever format the TMC can provide, and aligns it with controlled vocabularies.
 - **Sample** metadata is handled by Brendan Honick and Bill Shirey. [The standard operating procedure is outlined here.](https://docs.google.com/document/d/1K-PvBaduhrN-aU-vzWd9gZqeGvhGF3geTwRR0ww74Jo/edit)
 - **Dataset** uploads should be validated first by the TMCs. Dataset upload validation is the focus of this repo. [Details below.](#upload-process-and-upload-directory-structure)
 
 ## For assay type working groups:
 
 Before we can write code to validate a particular assay type, there are some prerequisites:
+
 - A document describing the experimental techniques involved.
 - A list of the metadata fields for this type, along with descriptions and constraints.
 - A list of the files to be expected in each dataset directory, along with descriptions.
   [Suggestions for describing directories](HOWTO-describe-directories.md).
 
 When all the parts are finalized,
+
 - The document will be translated into markdown, and added [here](https://github.com/hubmapconsortium/portal-docs/tree/main/assays).
 - The list of fields will be translated into a table schema, like those [here](src/ingest_validation_tools/table-schemas).
 - The list of files will be translated into a directory schema, like those [here](src/ingest_validation_tools/directory-schemas).
@@ -38,7 +42,14 @@ contact Phil Blood (@pdblood).
 
 ## For data submitters and curators:
 
+### Validate TSVs
+
+To validate your `*-metadata.tsv`, `contributors.tsv`, and `antibodies.tsv` files, use the [HuBMAP Metadata Spreadsheet Validator](https://metadatavalidator.metadatacenter.org/). This tool is a web-based application that will categorize any errors in your spreadsheet and provide help fixing those errors. More detailed instructions about using the tool can be found in the [Spreadsheet Validator Documentation](https://metadatacenter.github.io/spreadsheet-validator-docs/).
+
+### Validate directory structure
+
 Checkout the repo and install dependencies:
+
 ```
 python --version  # Should be Python3.
 git clone https://github.com/hubmapconsortium/ingest-validation-tools.git
@@ -53,37 +64,29 @@ You should see [the documention for `validate_upload.py`](script-docs/README-val
 **Note**: you need to have _git_ installed in your system.
 
 Now run it against one of the included examples, giving the path to an upload directory:
+
 ```
 src/validate_upload.py \
   --local_directory examples/dataset-examples/bad-tsv-formats/upload \
+  --offline \
   --output as_text
 ```
 
 You should now see [this (extensive) error message](examples/dataset-examples/bad-tsv-formats/README.md).
 This example TSV has been constructed with a mistake in every column, just to demonstrate the checks which are available. Hopefully, more often your experience will be like this:
+
 ```
 src/validate_upload.py \
-  --local_directory examples/dataset-examples/good-codex-akoya/upload
+  --local_directory examples/dataset-examples/good-codex-akoya-directory-v1-with-dataset.json/upload \
+  --offline
 ```
+
 ```
 No errors!
 ```
 
 Documentation and metadata TSV templates for each assay type are [here](https://hubmapconsortium.github.io/ingest-validation-tools/).
 Addition help for certain common error messages is available [here](README-validate-upload-help.md)
-
-### Validating single TSVs:
-
-If you don't have an entire upload directory at hand, you can validate individual
-metadata, antibodies, contributors, or sample TSVs:
-```
-src/validate_tsv.py \
-  --schema metadata \
-  --path examples/dataset-examples/good-scatacseq-v1/upload/metadata.tsv
-```
-```
-No errors!
-```
 
 ### Running plugin tests:
 
@@ -101,21 +104,26 @@ pip install -r requirements.txt
 # Back to ingest-validation-tools...
 cd ../ingest-validation-tools
 src/validate_upload.py \
-  --local_directory examples/dataset-examples/good-codex-akoya/upload \
+  --local_directory examples/dataset-examples/good-codex-akoya-directory-v1-with-dataset.json/upload \
+  --offline \
+  --run_plugins \
   --plugin_directory ../ingest-validation-tests/src/ingest_validation_tests/
 ```
 
 ## For developers and contributors:
 
-A good example is of programatic usage is `validate-upload.py`; In a nutshell:
+An example of the core error-reporting functionality underlying `validate-upload.py`:
+
 ```python
 upload = Upload(directory_path=path)
 report = ErrorReport(upload.get_errors())
 print(report.as_text())
 ```
+
 (If it would be useful for this to be installable with `pip`, please file an issue.)
 
 To make contributions, checkout the project, cd, venv, and then:
+
 ```
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
@@ -128,15 +136,18 @@ After making tweaks to the schema, you will need to regenerate the docs:
 The test error message will tell you what to do.
 
 For releases we're just using git tags:
+
 ```
 $ git tag v0.0.x
 $ git push origin v0.0.x
 ```
 
 ### Repo structure
+
 [![Repo structure](https://docs.google.com/drawings/d/e/2PACX-1vQ8gorGI8ceYBf0bIJQlw4HvI3ooVTvCfickHhCvGJU4yy5kViJI39oqQ7xB20WLYxv8FMRuBLGwmH-/pub?w=600)](https://docs.google.com/drawings/d/1UK81oUHTSHetGXRsA-YeSFS-kb6Nw2rNpnw8SBysYXU/edit)
 
 Checking in the built documentation is not the typical approach, but has worked well for this project:
+
 - It's a sanity check when making schema changes. Since the schema for an assay actually comes for multiple sources, having the result of include resolution checked in makes it possible to catch unintended changes.
 - It simplifies administration, since a separate static documentation site is not required.
 - It enables easy review of the history of a schema, since the usual git/github tools can be used.
@@ -144,6 +155,7 @@ Checking in the built documentation is not the typical approach, but has worked 
 ## Upload process and upload directory structure
 
 Data upload to HuBMAP is composed of discrete phases:
+
 - Upload preparation and validation
 - Upload and re-validation
 - Restructuring
@@ -152,6 +164,7 @@ Data upload to HuBMAP is composed of discrete phases:
 [![Upload process](https://docs.google.com/drawings/d/e/2PACX-1vSlMUKk0QU1bboxbT3x6gEMRawZDjZH_PWma2ZKVsnqlIDaCg3OFKq2zQg9dW_2ty8U3Z4UEENhUMvR/pub?w=1000)](https://docs.google.com/drawings/d/1fDhORYm8DYnCnbvpIrMMN0OxFQakHir_Ss071q2ySNc/edit)
 
 Uploads are based on directories containing at a minimum:
+
 - one or more `*-metadata.tsv` files.
 - top-level dataset directories in a 1-to-1 relationship with the rows of the TSVs.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # ingest-validation-tools
-
 HuBMAP data upload guidelines and tools which check that uploads adhere to those guidelines.
 Assay documentation is on [Github Pages](https://hubmapconsortium.github.io/ingest-validation-tools/).
 
@@ -74,7 +73,6 @@ src/validate_upload.py \
   --local_directory examples/dataset-examples/good-codex-akoya-directory-v1-with-dataset.json/upload \
   --offline
 ```
-
 ```
 No errors!
 ```
@@ -112,11 +110,9 @@ upload = Upload(directory_path=path)
 report = ErrorReport(upload.get_errors())
 print(report.as_text())
 ```
-
 (If it would be useful for this to be installable with `pip`, please file an issue.)
 
 To make contributions, checkout the project, cd, venv, and then:
-
 ```
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
@@ -135,7 +131,6 @@ $ git push origin v0.0.x
 ```
 
 ### Repo structure
-
 [![Repo structure](https://docs.google.com/drawings/d/e/2PACX-1vQ8gorGI8ceYBf0bIJQlw4HvI3ooVTvCfickHhCvGJU4yy5kViJI39oqQ7xB20WLYxv8FMRuBLGwmH-/pub?w=600)](https://docs.google.com/drawings/d/1UK81oUHTSHetGXRsA-YeSFS-kb6Nw2rNpnw8SBysYXU/edit)
 
 Checking in the built documentation is not the typical approach, but has worked well for this project:

--- a/script-docs/README-validate_upload.py.md
+++ b/script-docs/README-validate_upload.py.md
@@ -54,7 +54,8 @@ Typical usage:
   extra parameters.
 
   --run_plugins + --plugin_directory ../ingest-validation-tests/src/ingest_validation_tests/:
-  Additional plugin tests can be run to confirm that files in the upload directory are valid; requires cloning https://github.com/hubmapconsortium/ingest-validation-tests.
+  Additional plugin tests can be run to confirm that files in the upload directory are valid;
+  requires cloning https://github.com/hubmapconsortium/ingest-validation-tests.
 
 Exit status codes:
   0: Validation passed

--- a/script-docs/README-validate_upload.py.md
+++ b/script-docs/README-validate_upload.py.md
@@ -53,6 +53,9 @@ Typical usage:
   and one-line TSVs are put in each dataset directory. This structure needs
   extra parameters.
 
+  --run_plugins + --plugin_directory ../ingest-validation-tests/src/ingest_validation_tests/:
+  Additional plugin tests can be run to confirm that files in the upload directory are valid; requires cloning https://github.com/hubmapconsortium/ingest-validation-tests.
+
 Exit status codes:
   0: Validation passed
   1: Unexpected bug

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -378,6 +378,8 @@ class Upload:
         the TSV fields, which makes frictionless confused and upset.
         """
         errors: Dict = {}
+        if self.offline:
+            return errors
 
         # assay -> parent_sample_id
         # sample -> sample_id

--- a/src/validate_upload.py
+++ b/src/validate_upload.py
@@ -35,6 +35,10 @@ Typical usage:
   and one-line TSVs are put in each dataset directory. This structure needs
   extra parameters.
 
+  --run_plugins + --plugin_directory ../ingest-validation-tests/src/ingest_validation_tests/:
+  Additional plugin tests can be run to confirm that files in the upload directory are valid;
+  requires cloning https://github.com/hubmapconsortium/ingest-validation-tests.
+
 Exit status codes:
   {exit_codes.VALID}: Validation passed
   {exit_codes.BUG}: Unexpected bug


### PR DESCRIPTION
Updating `validate_upload.py` documentation to add spreadsheet validator link and instructions. Cleanup of broken examples and some phrasing.

- The "For assay type working groups" section seems like it's out of date but that is beyond my expertise. There may be other pieces that the move to next-gen templates have made obsolete that I don't have the knowledge to catch.
- I suspect we want to explicitly deprecate the use of `validate_tsv.py` by users but have not yet done so.
- I am not sure why the update to 'README-validate_upload.py` didn't stick, have to troubleshoot further.

This will require another update when the soft assay type revision is released because users will need a Globus token.