### PR TITLE
Stripping trailing slash on ingest url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Update GeoMx NGS directory schema
 - Ported murine from SenNet
 - Update Histology directory schema
+- Bugfix stripping trailing slash in ingest api url
 
 ## v0.0.17
 

--- a/src/ingest_validation_tools/validation_utils.py
+++ b/src/ingest_validation_tools/validation_utils.py
@@ -127,7 +127,7 @@ def get_assaytype_data(
     if not ingest_url:
         ingest_url = "https://ingest.api.hubmapconsortium.org/"
     response = requests.post(
-        f"{ingest_url}/assaytype",
+        f"""{ingest_url.strip("/")}/assaytype""",
         headers={"Content-Type": "application/json"},
         data=json.dumps(row),
     )


### PR DESCRIPTION
Stripping trailing slash for ingest url since ingest-api might not have handles for double slashed urls.