### PR TITLE
Allow comma-separated parent_sample_id values in URL checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Directory validation changes for "shared" uploads
 - Update Phenocycler directory schema
 - Remove bad paths from LC-MS directory schema
+- Allow multiple comma-separated parent_sample_id values
 
 ## v0.0.18
 

--- a/examples/dataset-examples/bad-cedar-assay-histology/README.md
+++ b/examples/dataset-examples/bad-cedar-assay-histology/README.md
@@ -13,9 +13,8 @@ Metadata TSV Validation Errors:
     examples/dataset-examples/bad-cedar-assay-histology/upload/bad-histology-metadata.tsv:
       URL Errors:
       - 'On row 2, column "parent_sample_id", value "wrong" fails because of error
-        "HTTPError": 401 Client Error: Unauthorized for url: https://entity.api.hubmapconsortium.org/entities/wrong.'
-      - 'On row 3, column "parent_sample_id", value "HBM854.FXDQ.783" fails because
-        of error "HTTPError": 401 Client Error: Unauthorized for url: https://entity.api.hubmapconsortium.org/entities/HBM854.FXDQ.783'
+        "HTTPError": Field value is not valid; URL https://entity.api.hubmapconsortium.org/entities/wrong
+        returned a 400 Error.'
       Validation Errors:
       - On row 0, column "parent_sample_id", value "wrong" fails because of error
         "invalidValueFormat".

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -568,9 +568,9 @@ class Upload:
             check = {k: v for k, v in row.items() if k in constrained_fields}
             for field, value in check.items():
                 if field == "parent_sample_id":
-                    ids = value.split(", ")
+                    ids = value.split(",")
                     for id in ids:
-                        error = self._check_single_url(field, id, constrained_fields, i)
+                        error = self._check_single_url(field, id.strip(), constrained_fields, i)
                         if error:
                             url_errors.append(self._get_message(error, report_type))
                 else:


### PR DESCRIPTION
Can be abstracted, went down that path first but it felt potentially over-engineered.