### PR TITLE
Change to fix row numbering discrepancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Revert deprecation of field YAML files
 - Update MUSIC directory schema
 - Add semantic version to plugin test base class
+- Fix row number mismatch between validation and spreadsheet validator response
 
 ## v0.0.18
 

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -595,7 +595,7 @@ class Upload:
             error = {
                 "errorType": type(e).__name__,
                 "column": field,
-                "row": row_num + 2,
+                "row": row_num + 1,
                 "value": value,
                 "error_text": e.__str__(),
             }

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -313,9 +313,10 @@ class Upload:
         if response.status_code != 200:
             raise Exception(response.json())
         elif response.json().get("reporting") and len(response.json().get("reporting")) > 0:
-            errors.extend(
-                [self._get_message(error, report_type) for error in response.json()["reporting"]]
-            )
+            for error in response.json()["reporting"]:
+                normalized_row = error.get("row") + 1
+                error["row"] = normalized_row
+                errors.append(self._get_message(error, report_type))
         else:
             logging.info(f"No errors found during CEDAR validation for {tsv_path}!")
             logging.info(f"Response: {response.json()}.")


### PR DESCRIPTION
Row numbers didn't match between Spreadsheet Validator response and IVT validation. This change mutates the Spreadsheet Validator responses because they are less human-readable to start with. Errors returned by failed URL checks have also always had an off-by-one row number so that is fixed here.