### PR TITLE
Upload.multi_parent logging fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.0.21
 - Fix the changelog to reflect the current version.
 - Fix row number mismatch between validation and spreadsheet validator response
+- Fix logging length issue in Upload.multi_parent
 
 ## v0.0.20
 - Fix row number mismatch between validation and spreadsheet validator response

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -461,7 +461,7 @@ class Upload:
             return
         if len(multi_assay_parents) > 1:
             raise PreflightError(
-                f"Upload contains multiple parent multi-assay types: {multi_assay_parents}"
+                f"Upload contains multiple parent multi-assay types: {', '.join([parent.schema_name for parent in multi_assay_parents])}"
             )
         return multi_assay_parents[0]
 


### PR DESCRIPTION
Fixes the issue where the PreflightError contained the entire SchemaVersion (including all TSV rows) if multiple parent type TSVs were found when getting the self.multi_parent value. Will now just log the dataset types of the offending TSVs.

Added a test for Upload.multi_parent because I am trying to more opportunistically add tests.