### PR TITLE
Upload: Use the path name rather than the full path when comparing to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removing references to deprecated Search API endpoint 'assayname'
 - Update Phenocycler directory schema
 - Update GeoMx NGS directory schema
+- Update shared upload check
 
 ## v0.0.26
 - Update GeoMx NGS directory schema

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -96,7 +96,7 @@ class Upload:
                 self._check_single_assay()
 
             self.is_shared_upload = {"global", "non_global"} == {
-                x
+                x.name
                 for x in self.directory_path.glob("*global")
                 if x.is_dir() and x.name in ["global", "non_global"]
             }


### PR DESCRIPTION
… {"global", "non_global"}