### PR TITLE
Juranic/undo cosmxdirschema updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
  - Update Visium with probes directory schema
  - Update Xenium directory schema
  - Update Segmentation Mask directory schema
+ - Undo version 2.3 updates and keep version 2.4 updates to CosMx directory schema
 
 
 ## v0.0.33

--- a/src/ingest_validation_tools/directory-schemas/cosmx-v2.4.yaml
+++ b/src/ingest_validation_tools/directory-schemas/cosmx-v2.4.yaml
@@ -52,7 +52,7 @@ files:
   -
     pattern: raw\/transcript_locations\.csv$
     required: False
-    description: 'Contains decription of the location of all decoded transcripts. The origin of the coordinate is 0,0 at the top left corner of the image. The file should include: gene name, x, y, z (optional), quality score (optional). It is expected that the first row in the file contains the column header.'
+    description: 'Contains description of the location of all decoded transcripts. The origin of the coordinate is 0,0 at the top left corner of the image. The file should include: gene name, x, y, z (optional), quality score (optional). It is expected that the first row in the file contains the column header.'
   -
     pattern: raw\/custom_gene_list\.csv$
     required: False
@@ -61,18 +61,6 @@ files:
     pattern: raw\/probes\.csv$
     required: False
     description: A CSV file describing the probe panel used. This is typically what's used to specifiy the probe set when ordering a probe panel for a Xenium run.
-  -
-    pattern: raw\/images\/FOV[^\/]*\/.*
-    required: True
-    description: Directory containing imaging tiles.
-  -
-    pattern: raw\/images\/FOV[^\/]*\/[^\/]*_complete_code_cell_target_call_coord\.csv$
-    required: True
-    description: Target coordinates and counts per cell.
-  -
-    pattern: raw\/images\/FOV[^\/]*\/[^\/]+\.(?:tif|tiff)$
-    required: True
-    description: The tiled image.
   -
     pattern: raw\/images\/overlay\.(?:jpeg|tiff|tif)$
     required: False
@@ -85,3 +73,18 @@ files:
     pattern: lab_processed\/.*
     required: True
     description: Experiment files that were processed by the lab generating the data.
+  -
+    pattern: lab_processed\/images\/.*
+    required: True
+    description: Processed image files
+  -
+    pattern: lab_processed\/images\/[^\/]+\.ome\.(?:tif|tiff)$
+    required: True
+    description: OME-TIFF files (multichannel, multi-layered) produced by the microscopy experiment. If compressed, must use loss-less compression algorithm. For Visium this stitched file should only include the single capture area relevant to the current dataset. For GeoMx there will be one OME TIFF file per slide, with each slide including multiple AOIs. See the following link for the set of fields that are required in the OME TIFF file XML header. <https://docs.google.com/spreadsheets/d/1YnmdTAA0Z9MKN3OjR3Sca8pz-LNQll91wdQoRPSP6Q4/edit#gid=0>
+    is_qa_qc: False
+    example: lab_processed/images/HBM892.MDXS.293.ome.tiff
+  -
+    pattern: lab_processed\/images\/[^\/]*ome-(?:tif|tiff)\.channels\.csv$
+    required: True
+    description: This file provides essential documentation pertaining to each channel of the accompanying OME TIFF. The file should contain one row per OME TIFF channel. The required fields are detailed <https://docs.google.com/spreadsheets/d/1xEJSb0xn5C5fB3k62pj1CyHNybpt4-YtvUs5SUMS44o/edit#gid=0>
+    is_qa_qc: False


### PR DESCRIPTION
Rollback CosMx directory schema changes (version 2.3) and keep .tif / .tiff extension handling from version 2.4