### PR TITLE
Bugfix plugin error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # Generated and deleted during successful tests.
 docs-test/
 
+*url-status-cache.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Ensure that shared uploads do not have extra top-level dirs
 - Update Visium (with probes) directory schema
 - Remove url-status-cache.json to avoid issues with permissions
+- Bugfix plugin error sorting
 
 ## v1.1.2
 

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -928,10 +928,10 @@ class Upload:
                 errors["Unexpected Plugin Error"] = [e]
         for k, v in errors.items():
             try:
-                # Optimistically assume v is a list of strings
+                # Optimistically assume v is a dict or list of strings
                 self.errors.plugin[k] = sorted(v)
             except TypeError:
-                # v was not a list of strings
+                # v was not a dict or list of strings
                 self.errors.plugin[k] = v
 
     ###################################

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -927,7 +927,12 @@ class Upload:
                 # We are ok with just returning a single error, rather than all.
                 errors["Unexpected Plugin Error"] = [e]
         for k, v in errors.items():
-            self.errors.plugin[k] = sorted(v)
+            try:
+                # Optimistically assume v is a list of strings
+                self.errors.plugin[k] = sorted(v)
+            except TypeError:
+                # v was not a list of strings
+                self.errors.plugin[k] = v
 
     ###################################
     #


### PR DESCRIPTION
Makes sorting the plugin errors safe if data doesn't match expected format. Also adds `url-status-cache.json` to `.gitignore`.