### PR TITLE
Address failing tests on new releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v1.1.3 (in progress)
+## v1.1.4
+
+- Fixing tests to prevent CHANGELOG.md error on release tags
+
+## v1.1.3
 
 - Update publication docs
 - Correct misspelled "relevant" in several file descriptions

--- a/tests/test-basics.sh
+++ b/tests/test-basics.sh
@@ -9,8 +9,13 @@ echo "Running doctests with pytest..."
 pytest --doctest-modules --ignore="tests/" --ignore="_deprecated/"
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-echo "GitHub branch: $BRANCH"
-if [ "$BRANCH" != 'main' ]; then
+
+if [[ "$BRANCH" == 'main' ]] ; then
+    echo "On GitHub branch $BRANCH, not checking CHANGELOG.md"
+elif [[ ! $(git symbolic-ref --short HEAD) ]] ; then
+    echo "Not on branch, not checking CHANGELOG.md (should only happen on tagged release)"
+else
+    echo "GitHub branch: $BRANCH"
     echo "Checking CHANGELOG.md..."
     diff CHANGELOG.md <(curl -s https://raw.githubusercontent.com/hubmapconsortium/ingest-validation-tools/main/CHANGELOG.md) \
         && die 'Update CHANGELOG.md'


### PR DESCRIPTION
New releases show failing tests because of "Update CHANGELOG.md" error. Added logic to not diff CHANGELOG.md when a tag is checked out, e.g. when a new release is being created.

If on branch main: do not diff changelog
If not on branch (tag checked out): do not diff changelog
Otherwise: diff changelog