### PR TITLE
Plugin kwargs

### DIFF
--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -109,7 +109,6 @@ def validation_error_iter(
         except Exception as e:
             raise ValidatorError(f"Could not import from plugin_dir {plugin_dir}: {e}")
         for val_class in validation_class_iter():
-            kwargs["verbose"] = verbose
             validator = val_class(
                 paths, assay_type, contains, verbose, schema, globus_token, app_context, **kwargs
             )

--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -48,7 +48,7 @@ def run_plugin_validators_iter(
     if is_shared_upload:
         paths = [Path(metadata_path).parent / "global", Path(metadata_path).parent / "non_global"]
         for k, v in validation_error_iter(
-            paths, sv.dataset_type, plugin_dir, sv.contains, **kwargs
+            paths, sv.dataset_type, plugin_dir, sv.contains, schema=sv, **kwargs
         ):
             yield k, v
     else:
@@ -109,9 +109,9 @@ def validation_error_iter(
         except Exception as e:
             raise ValidatorError(f"Could not import from plugin_dir {plugin_dir}: {e}")
         for val_class in validation_class_iter():
-            validator = val_class(
-                paths, assay_type, contains, verbose, schema, globus_token, app_context
-            )
             kwargs["verbose"] = verbose
-            for err in validator.collect_errors(**kwargs):
+            validator = val_class(
+                paths, assay_type, contains, verbose, schema, globus_token, app_context, **kwargs
+            )
+            for err in validator.collect_errors():
                 yield val_class, err

--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -48,7 +48,13 @@ def run_plugin_validators_iter(
     if is_shared_upload:
         paths = [Path(metadata_path).parent / "global", Path(metadata_path).parent / "non_global"]
         for k, v in validation_error_iter(
-            paths, sv.dataset_type, plugin_dir, sv.contains, schema_rows=sv.rows, **kwargs
+            paths,
+            sv.dataset_type,
+            plugin_dir,
+            sv.contains,
+            verbose=verbose,
+            schema_rows=sv.rows,
+            **kwargs,
         ):
             yield k, v
     else:

--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -43,15 +43,6 @@ def run_plugin_validators_iter(
         if column_name in sv.rows[0]:
             if any(row[column_name] != sv.dataset_type for row in sv.rows):
                 raise ValidatorError(f"{metadata_path} contains more than one assay type")
-    shared_kwargs = {
-        "assay_type": sv.dataset_type,
-        "plugin_dir": plugin_dir,
-        "contains": sv.contains,
-        "verbose": verbose,
-        "schema_rows": sv.rows,
-        "globus_token": globus_token,
-        "app_context": app_context,
-    } | kwargs
     if is_shared_upload:
         data_paths = [
             Path(metadata_path).parent / "global",
@@ -59,7 +50,17 @@ def run_plugin_validators_iter(
         ]
     else:
         data_paths = get_data_paths_from_tsv(metadata_path, sv)
-    for k, v in validation_error_iter(data_paths, **shared_kwargs):
+    for k, v in validation_error_iter(
+        data_paths,
+        assay_type=sv.dataset_type,
+        plugin_dir=plugin_dir,
+        contains=sv.contains,
+        verbose=verbose,
+        schema_rows=sv.rows,
+        globus_token=globus_token,
+        app_context=app_context,
+        **kwargs,
+    ):
         yield k, v
 
 

--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -1,14 +1,14 @@
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Optional, TypeVar, Union
+from typing import TypeVar
 
 from ingest_validation_tools.schema_loader import SchemaVersion
 from ingest_validation_tools.validation_utils import add_path
 
 # KeyValuePair type hint is robust, but Validator is not available here; use generic
 ValidatorGeneric = TypeVar("ValidatorGeneric")
-KeyValuePair = Iterator[tuple[ValidatorGeneric, list[Union[str, None]]]]
-PathOrStr = Union[str, Path]
+KeyValuePair = Iterator[tuple[ValidatorGeneric, list[str | None]]]
+PathOrStr = str | Path
 
 
 class ValidatorError(Exception):
@@ -48,7 +48,7 @@ def run_plugin_validators_iter(
     if is_shared_upload:
         paths = [Path(metadata_path).parent / "global", Path(metadata_path).parent / "non_global"]
         for k, v in validation_error_iter(
-            paths, sv.dataset_type, plugin_dir, sv.contains, schema=sv, **kwargs
+            paths, sv.dataset_type, plugin_dir, sv.contains, schema_rows=sv.rows, **kwargs
         ):
             yield k, v
     else:
@@ -67,7 +67,7 @@ def run_plugin_validators_iter(
                 plugin_dir,
                 sv.contains,
                 verbose=verbose,
-                schema=sv,
+                schema_rows=sv.rows,
                 globus_token=globus_token,
                 app_context=app_context,
                 **kwargs,
@@ -83,7 +83,7 @@ def validation_error_iter(
     plugin_dir: PathOrStr,
     contains: list,
     verbose: bool = False,
-    schema: Optional[SchemaVersion] = None,
+    schema_rows: list[dict] = [],
     globus_token: str = "",
     app_context: dict[str, str] = {},
     **kwargs,
@@ -110,7 +110,14 @@ def validation_error_iter(
             raise ValidatorError(f"Could not import from plugin_dir {plugin_dir}: {e}")
         for val_class in validation_class_iter():
             validator = val_class(
-                paths, assay_type, contains, verbose, schema, globus_token, app_context, **kwargs
+                paths,
+                assay_type,
+                contains,
+                verbose,
+                schema_rows,
+                globus_token,
+                app_context,
+                **kwargs,
             )
             for err in validator.collect_errors():
                 yield val_class, err

--- a/src/ingest_validation_tools/plugin_validator.py
+++ b/src/ingest_validation_tools/plugin_validator.py
@@ -43,44 +43,40 @@ def run_plugin_validators_iter(
         if column_name in sv.rows[0]:
             if any(row[column_name] != sv.dataset_type for row in sv.rows):
                 raise ValidatorError(f"{metadata_path} contains more than one assay type")
-
-    data_paths = []
+    shared_kwargs = {
+        "assay_type": sv.dataset_type,
+        "plugin_dir": plugin_dir,
+        "contains": sv.contains,
+        "verbose": verbose,
+        "schema_rows": sv.rows,
+        "globus_token": globus_token,
+        "app_context": app_context,
+    } | kwargs
     if is_shared_upload:
-        paths = [Path(metadata_path).parent / "global", Path(metadata_path).parent / "non_global"]
-        for k, v in validation_error_iter(
-            paths,
-            sv.dataset_type,
-            plugin_dir,
-            sv.contains,
-            verbose=verbose,
-            schema_rows=sv.rows,
-            **kwargs,
-        ):
-            yield k, v
+        data_paths = [
+            Path(metadata_path).parent / "global",
+            Path(metadata_path).parent / "non_global",
+        ]
     else:
-        if all("data_path" in row for row in sv.rows):
-            for row in sv.rows:
-                data_path = Path(row["data_path"])
-                if not data_path.is_absolute():
-                    data_path = Path(metadata_path).parent / data_path
-                if not data_path.is_dir():
-                    raise ValidatorError(f"{data_path} should be the base directory of a dataset")
-                data_paths.append(data_path)
-            print(f"Data paths being passed to plugins: {data_paths}")
-            for k, v in validation_error_iter(
-                data_paths,
-                sv.dataset_type,
-                plugin_dir,
-                sv.contains,
-                verbose=verbose,
-                schema_rows=sv.rows,
-                globus_token=globus_token,
-                app_context=app_context,
-                **kwargs,
-            ):
-                yield k, v
-        else:
-            raise ValidatorError(f"{metadata_path} is missing values in 'data_path' column")
+        data_paths = get_data_paths_from_tsv(metadata_path, sv)
+    for k, v in validation_error_iter(data_paths, **shared_kwargs):
+        yield k, v
+
+
+def get_data_paths_from_tsv(metadata_path: PathOrStr, sv: SchemaVersion):
+    data_paths = []
+    if all("data_path" in row for row in sv.rows):
+        for row in sv.rows:
+            data_path = Path(row["data_path"])
+            if not data_path.is_absolute():
+                data_path = Path(metadata_path).parent / data_path
+            if not data_path.is_dir():
+                raise ValidatorError(f"{data_path} should be the base directory of a dataset")
+            data_paths.append(data_path)
+        print(f"Data paths being passed to plugins: {data_paths}")
+    else:
+        raise ValidatorError(f"{metadata_path} is missing values in 'data_path' column")
+    return data_paths
 
 
 def validation_error_iter(

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -65,7 +65,7 @@ class Upload:
         encoding: str = "utf-8",
         offline_only: bool = False,
         ignore_deprecation: bool = False,
-        extra_parameters: Union[dict, None] = None,
+        plugin_kwargs: Union[dict, None] = None,
         globus_token: str = "",
         run_plugins: Optional[bool] = None,
         app_context: dict = {},
@@ -83,7 +83,7 @@ class Upload:
         self.encoding = encoding
         self.offline_only = offline_only
         self.ignore_deprecation = ignore_deprecation
-        self.extra_parameters = extra_parameters if extra_parameters else {}
+        self.plugin_kwargs = plugin_kwargs if plugin_kwargs else {}
         self.globus_token = globus_token
         self.run_plugins = run_plugins
         self.verbose = verbose
@@ -146,7 +146,7 @@ class Upload:
         self.get_info_called = True
         return self.info
 
-    def get_errors(self, **kwargs) -> ErrorDict:
+    def get_errors(self) -> ErrorDict:
         """
         When converted using ErrorDict.as_dict(), keys are
         present only if there is actually an error to report.
@@ -160,7 +160,7 @@ class Upload:
         self.validate_metadata()
         self.get_directory_errors()
         self.get_reference_errors()
-        self.get_file_errors(**kwargs | self.extra_parameters)
+        self.get_file_errors()
 
         self.get_errors_called = True
         return self.errors
@@ -227,8 +227,7 @@ class Upload:
                 )
             self._find_supporting_metadata(schema)
             for supporting_type in [*schema.antibodies_schemas, *schema.contributors_schemas]:
-                if supporting_type:
-                    self.validate_metadata(tsv_paths={supporting_type.path: supporting_type})
+                self.validate_metadata(tsv_paths={supporting_type.path: supporting_type})
 
     def validate_metadata(
         self,
@@ -289,7 +288,7 @@ class Upload:
         if shared_dir_errors := self.__get_shared_dir_errors():
             self.errors.reference.update({"Shared Directory References": shared_dir_errors})
 
-    def get_file_errors(self, **kwargs):
+    def get_file_errors(self):
         """
         Run file-level validation. Plugin error checking is costly;
         by default this bails if other errors have been found already.
@@ -302,10 +301,10 @@ class Upload:
                 )
             else:  # no errors, run plugins
                 logging.info("Running plugin validation...")
-                self._get_plugin_errors(**kwargs)
+                self._get_plugin_errors()
         elif self.run_plugins:
             logging.info("Running plugin validation...")
-            self._get_plugin_errors(**kwargs)
+            self._get_plugin_errors()
         else:
             logging.info("Skipping plugin validation.")
 
@@ -897,7 +896,7 @@ class Upload:
     #
     ###################################
 
-    def _get_plugin_errors(self, **kwargs) -> None:
+    def _get_plugin_errors(self) -> None:
         plugin_path = self.plugin_directory
         if not plugin_path:
             return
@@ -917,7 +916,7 @@ class Upload:
                         verbose=self.verbose,
                         globus_token=self.globus_token,
                         app_context=self.app_context,
-                        **kwargs,
+                        **self.plugin_kwargs,
                     ):
                         if v is None:
                             self.info.successful_plugins.append(k.__name__)

--- a/src/ingest_validation_tools/upload.py
+++ b/src/ingest_validation_tools/upload.py
@@ -146,11 +146,12 @@ class Upload:
         self.get_info_called = True
         return self.info
 
-    def get_errors(self) -> ErrorDict:
+    def get_errors(self, **kwargs) -> ErrorDict:
         """
         When converted using ErrorDict.as_dict(), keys are
         present only if there is actually an error to report.
         """
+        # TODO: remove deprecated kwargs param
         # Return if PreflightErrors found
         if self.errors:
             return self.errors


### PR DESCRIPTION
## Note
This PR is required for update to IVTests but maintains backward compatibility with current ingest-pipeline code (so the upstream work can be merged/released when convenient).

## Updates
- Renamed `Upload.extra_parameters` -> `Upload.plugin_kwargs`.*
- To be removed:  `**kwargs` param from `Upload.get_errors()`. Use `Upload.plugin_kwargs` param to pass plugin-specific kwargs instead.*
- Pass `Upload.plugin_kwargs` down to plugins.

\* Separate PR to `ingest-pipeline` required (see: https://github.com/hubmapconsortium/ingest-pipeline/pull/1278). Param preserved briefly for the switchover. Plugin kwargs will not be passed to plugins until `ingest-pipeline` is updated, but I'm not convinced they were being passed in properly before so I think this is fine.

## Bugfixes
- Ensured uniformity in kwargs passed to plugins between shared/non-shared uploads.
     - Plugins will receive `schema_rows`.
     - Plugins will log the same based on `verbose`.